### PR TITLE
DAOS-279 log: Avoid changing caller input entry

### DIFF
--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -103,16 +103,17 @@ int log_append_entry(log_t* me_, raft_entry_t* c)
 
     __ensurecapacity(me);
 
+    memcpy(&me->entries[me->back], c, sizeof(raft_entry_t));
+
     if (me->cb && me->cb->log_offer)
     {
         void* ud = raft_get_udata(me->raft);
-        e = me->cb->log_offer(me->raft, ud, c, me->back);
-        raft_offer_log(me->raft, c, me->back);
+        e = me->cb->log_offer(me->raft, ud, &me->entries[me->back], me->back);
+        raft_offer_log(me->raft, &me->entries[me->back], me->back);
         if (e == RAFT_ERR_SHUTDOWN)
             return e;
     }
 
-    memcpy(&me->entries[me->back], c, sizeof(raft_entry_t));
     me->count++;
     me->back++;
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -626,12 +626,8 @@ int raft_recv_entry(raft_server_t* me_,
     __log(me_, NULL, "received entry t:%d id: %d idx: %d",
           me->current_term, e->id, raft_get_current_idx(me_) + 1);
 
-    raft_entry_t ety;
-    ety.term = me->current_term;
-    ety.id = e->id;
-    ety.type = e->type;
-    memcpy(&ety.data, &e->data, sizeof(raft_entry_data_t));
-    raft_append_entry(me_, &ety);
+    e->term = me->current_term;
+    raft_append_entry(me_, e);
     for (i = 0; i < me->num_nodes; i++)
     {
         if (me->node == me->nodes[i] || !me->nodes[i] ||

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -224,6 +224,7 @@ void TestRaft_server_append_entry_user_can_set_data_buf(CuTest * tc)
     raft_cbs_t funcs = {
         .log_offer = __raft_logentry_offer,
     };
+    char *buf = "aaa";
 
     void *r = raft_new();
     raft_set_state(r, RAFT_STATE_CANDIDATE);
@@ -233,11 +234,14 @@ void TestRaft_server_append_entry_user_can_set_data_buf(CuTest * tc)
     ety.term = 1;
     ety.id = 100;
     ety.data.len = 4;
-    ety.data.buf = (unsigned char*)"aaa";
+    ety.data.buf = buf;
     raft_append_entry(r, &ety);
+    /* User's input entry is intact. */
+    CuAssertTrue(tc, ety.data.buf == buf);
     raft_entry_t* kept =  raft_get_entry_from_idx(r, 1);
     CuAssertTrue(tc, NULL != kept->data.buf);
-    CuAssertTrue(tc, kept->data.buf == ety.data.buf);
+    /* Data buf is the one set by log_offer. */
+    CuAssertTrue(tc, kept->data.buf == tc);
 }
 
 #if 0


### PR DESCRIPTION
log_append_entry() passes caller's raft_entry_t to log_offer. If the
log_offer implementation sets the data buffer to different value,
caller's raft_entry_t gets modified as a side effect. This is
error-prone as callers are usually responsible for freeing the data
buffer with such a log_offer implementation. This patch passes the
raft_entry_t in the log to log_offer instead. Also, ety in
raft_recv_entry() is no longer required.

Signed-off-by: Li Wei <wei.g.li@intel.com>