### PR TITLE
DAOS-279 server: Discard current_leader when term changes

### DIFF
--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -51,7 +51,7 @@ typedef struct {
     int election_timeout;
     int request_timeout;
 
-    /* what this node thinks is the node ID of the current leader, or -1 if
+    /* what this node thinks is the node ID of the current leader, or NULL if
      * there isn't a known current leader. */
     raft_node_t* current_leader;
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -236,6 +236,7 @@ int raft_recv_appendentries_response(raft_server_t* me_,
     {
         raft_set_current_term(me_, r->term);
         raft_become_follower(me_);
+        me->current_leader = NULL;
         return 0;
     }
     else if (me->current_term != r->term)
@@ -349,6 +350,9 @@ int raft_recv_appendentries(
         goto fail_with_current_idx;
     }
 
+    /* update current leader because ae->term is up to date */
+    me->current_leader = node;
+
     /* Not the first appendentries we've received */
     /* NOTE: the log starts at 1 */
     if (0 < ae->prev_log_idx)
@@ -429,9 +433,6 @@ int raft_recv_appendentries(
         raft_set_commit_idx(me_, min(last_log_idx, ae->leader_commit));
     }
 
-    /* update current leader because we accepted appendentries from it */
-    me->current_leader = node;
-
     r->success = 1;
     r->first_idx = ae->prev_log_idx + 1;
     return 0;
@@ -498,6 +499,7 @@ int raft_recv_requestvote(raft_server_t* me_,
     {
         raft_set_current_term(me_, vr->term);
         raft_become_follower(me_);
+        me->current_leader = NULL;
     }
 
     if (__should_grant_vote(me, vr))
@@ -566,6 +568,7 @@ int raft_recv_requestvote_response(raft_server_t* me_,
     {
         raft_set_current_term(me_, r->term);
         raft_become_follower(me_);
+        me->current_leader = NULL;
         return 0;
     }
     else if (raft_get_current_term(me_) != r->term)


### PR DESCRIPTION
When a leader learns of a newer term and steps down, it should discard
current_leader. Otherwise, a client request may be rejected with
RAFT_ERR_NOT_LEADER and a hint pointing to this replica itself!

For simplicity, this patche follows the Raft paper to discard
current_leader whenever current_term changes. And, when receiving an AE
with an up-to-date term, a server always updates current_leader, as this
information is absolute, even if the previous entry doesn't match.

This patch also fixes a test that has previously been failing due to
incorrect node IDs.

Signed-off-by: Li Wei <wei.g.li@intel.com>