### PR TITLE
DAOS-279 server: Zero timeout_elapsed for leaders

### DIFF
--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -49,6 +49,7 @@ typedef struct {
     int num_nodes;
 
     int election_timeout;
+    int election_timeout_rand;
     int request_timeout;
 
     /* what this node thinks is the node ID of the current leader, or NULL if
@@ -79,6 +80,8 @@ void raft_become_follower(raft_server_t* me);
 void raft_vote(raft_server_t* me, raft_node_t* node);
 
 void raft_set_current_term(raft_server_t* me,int term);
+
+void raft_randomize_election_timeout(raft_server_t* me_);
 
 /**
  * @return 0 on error */

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -23,6 +23,7 @@ void raft_set_election_timeout(raft_server_t* me_, int millisec)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     me->election_timeout = millisec;
+    raft_randomize_election_timeout(me_);
 }
 
 void raft_set_request_timeout(raft_server_t* me_, int millisec)

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -14,6 +14,11 @@
 
 // TODO: leader doesn't timeout and cause election
 
+static int max_election_timeout(int election_timeout)
+{
+	return 2 * election_timeout;
+}
+
 void TestRaft_server_voted_for_records_who_we_voted_for(CuTest * tc)
 {
     void *r = raft_new();
@@ -1348,8 +1353,8 @@ void TestRaft_follower_becomes_candidate_when_election_timeout_occurs(
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
 
-    /*  1.001 seconds have passed */
-    raft_periodic(r, 1001);
+    /*  max election timeout have passed */
+    raft_periodic(r, max_election_timeout(1000) + 1);
 
     /* is a candidate now */
     CuAssertTrue(tc, 1 == raft_is_candidate(r));
@@ -1514,8 +1519,8 @@ void TestRaft_candidate_election_timeout_and_no_leader_results_in_new_election(
     raft_become_candidate(r);
     CuAssertTrue(tc, 1 == raft_get_current_term(r));
 
-    /* clock over (ie. 1000 + 1), causing new election */
-    raft_periodic(r, 1001);
+    /* clock over (ie. max election timeout + 1), causing new election */
+    raft_periodic(r, max_election_timeout(1000) + 1);
     CuAssertTrue(tc, 2 == raft_get_current_term(r));
 
     /*  receiving this vote gives the server majority */


### PR DESCRIPTION
If raft_become_candidate() assigns a negative value e (i.e.,
-election_timeout < e < 0) to timeout_elapsed, and if this replica
successfully becomes the leader, then this leader won't send heartbeats
for request_timeout - e milliseconds. This may be longer than
election_timeout and cause an unnecessary leadership change.

This patch zeroes timeout_elapsed in raft_become_leader(), randomizes
election timeouts in [election_timeout, 2 * election_timeout), and fixes
raft_recv_appendentries() to avoid zeroing timeout_elapsed if the AE
request has an older term.

Signed-off-by: Li Wei <wei.g.li@intel.com>