### PR TITLE
DAOS-417 log: Remove RAFT_LOGTYPE_SNAPSHOT

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -62,7 +62,6 @@ typedef enum {
      * Removing nodes is a 2 step process: first demote, then remove.
      */
     RAFT_LOGTYPE_REMOVE_NODE,
-    RAFT_LOGTYPE_SNAPSHOT,
     /**
      * Users can piggyback the entry mechanism by specifying log types that
      * are higher than RAFT_LOGTYPE_NUM.
@@ -724,7 +723,11 @@ void raft_set_commit_idx(raft_server_t* me, int commit_idx);
 int raft_append_entry(raft_server_t* me, raft_entry_t* ety);
 
 /** Confirm if a msg_entry_response has been committed.
- * @param[in] r The response we want to check */
+ * @param[in] r The response we want to check
+ * @return
+ *  1 if not committed
+ *  0 if not committed
+ *  -1 if overwritten or commitness unknown */
 int raft_msg_entry_response_committed(raft_server_t* me_,
                                       const msg_entry_response_t* r);
 

--- a/include/raft_log.h
+++ b/include/raft_log.h
@@ -49,8 +49,10 @@ raft_entry_t *log_peektail(log_t * me_);
 
 int log_get_current_idx(log_t* me_);
 
-int log_load_from_snapshot(log_t *me_, int idx, int term);
+void log_load_from_snapshot(log_t *me_, int idx, int term);
 
 int log_get_base(log_t* me_);
+
+int log_get_base_term(log_t* me_);
 
 #endif /* RAFT_LOG_H_ */

--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -33,6 +33,9 @@ typedef struct
     /* we compact the log, and thus need to increment the Base Log Index */
     int base;
 
+    /* term of the base */
+    int base_term;
+
     raft_entry_t* entries;
 
     /* callbacks */
@@ -75,28 +78,14 @@ static int __ensurecapacity(log_private_t * me)
     return 0;
 }
 
-int log_load_from_snapshot(log_t *me_, int idx, int term)
+void log_load_from_snapshot(log_t *me_, int idx, int term)
 {
     log_private_t* me = (log_private_t*)me_;
 
     log_clear(me_);
 
-    raft_entry_t ety;
-    ety.data.len = 0;
-    ety.id = 1;
-    ety.term = term;
-    ety.type = RAFT_LOGTYPE_SNAPSHOT;
-
-    int e = log_append_entry(me_, &ety);
-    if (e != 0)
-    {
-        assert(0);
-        return e;
-    }
-
-    me->base = idx - 1;
-
-    return 0;
+    me->base = idx;
+    me->base_term = term;
 }
 
 log_t* log_alloc(int initial_size)
@@ -134,6 +123,7 @@ void log_clear(log_t* me_)
     me->back = 0;
     me->front = 0;
     me->base = 0;
+    me->base_term = 0;
 }
 
 /** TODO: rename log_append */
@@ -254,6 +244,7 @@ int log_poll(log_t* me_, int idx)
     while (me->base + 1 <= idx)
     {
         int n = batch_up(me, me->base + 1, idx - (me->base + 1) + 1);
+        unsigned int term = me->entries[subscript(me, me->base + n)].term;
         if (me->cb && me->cb->log_poll)
         {
             int e = me->cb->log_poll(me->raft, raft_get_udata(me->raft),
@@ -265,6 +256,7 @@ int log_poll(log_t* me_, int idx)
         me->front = me->front % me->size;
         me->count -= n;
         me->base += n;
+        me->base_term = term;
     }
 
     return 0;
@@ -309,4 +301,9 @@ int log_get_current_idx(log_t* me_)
 int log_get_base(log_t* me_)
 {
     return ((log_private_t*)me_)->base;
+}
+
+int log_get_base_term(log_t* me_)
+{
+    return ((log_private_t*)me_)->base_term;
 }

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -250,6 +250,21 @@ raft_entry_t* raft_get_entry_from_idx(raft_server_t* me_, int etyidx)
     return log_get_at_idx(me->log, etyidx);
 }
 
+/* Returns nonzero if we've got the term at idx or zero otherwise. */
+static int raft_get_entry_term(raft_server_t* me_, int idx, int* term)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    int got = 1;
+    raft_entry_t* ety = raft_get_entry_from_idx(me_, idx);
+    if (ety)
+        *term = ety->term;
+    else if (idx == log_get_base(me->log))
+        *term = log_get_base_term(me->log);
+    else
+        got = 0;
+    return got;
+}
+
 int raft_voting_change_is_in_progress(raft_server_t* me_)
 {
     return ((raft_server_private_t*)me_)->voting_cfg_change_log_idx != -1;
@@ -333,10 +348,11 @@ int raft_recv_appendentries_response(raft_server_t* me_,
 
     /* Update commit idx */
     int point = r->current_idx;
-    if (point)
+    if (point && raft_get_commit_idx(me_) < point)
     {
-        raft_entry_t* ety = raft_get_entry_from_idx(me_, point);
-        if (raft_get_commit_idx(me_) < point && ety->term == me->current_term)
+        int term;
+        int got = raft_get_entry_term(me_, point, &term);
+        if (got && term == me->current_term)
         {
             int i, votes = 1;
             for (i = 0; i < me->num_nodes; i++)
@@ -357,7 +373,7 @@ int raft_recv_appendentries_response(raft_server_t* me_,
     }
 
     /* Aggressively send remaining entries */
-    if (raft_get_entry_from_idx(me_, raft_node_get_next_idx(node)))
+    if (raft_node_get_next_idx(node) <= raft_get_current_idx(me_))
         raft_send_appendentries(me_, node);
 
     /* periodic applies committed entries lazily */
@@ -414,20 +430,19 @@ int raft_recv_appendentries(
     /* NOTE: the log starts at 1 */
     if (0 < ae->prev_log_idx)
     {
-        raft_entry_t* ety = raft_get_entry_from_idx(me_, ae->prev_log_idx);
-
         /* 2. Reply false if log doesn't contain an entry at prevLogIndex
            whose term matches prevLogTerm (§5.3) */
-        if (!ety)
+        int term;
+        int got = raft_get_entry_term(me_, ae->prev_log_idx, &term);
+        if (!got && raft_get_current_idx(me_) < ae->prev_log_idx)
         {
             __log(me_, node, "AE no log at prev_idx %d", ae->prev_log_idx);
             goto out;
         }
-
-        if (ety->term != ae->prev_log_term)
+        else if (got && term != ae->prev_log_term)
         {
             __log(me_, node, "AE term doesn't match prev_term (ie. %d vs %d) ci:%d comi:%d lcomi:%d pli:%d",
-                  ety->term, ae->prev_log_term, raft_get_current_idx(me_),
+                  term, ae->prev_log_term, raft_get_current_idx(me_),
                   raft_get_commit_idx(me_), ae->leader_commit, ae->prev_log_idx);
             if (ae->prev_log_idx <= raft_get_commit_idx(me_))
             {
@@ -453,8 +468,9 @@ int raft_recv_appendentries(
     {
         raft_entry_t* ety = &ae->entries[i];
         int ety_index = ae->prev_log_idx + 1 + i;
-        raft_entry_t* existing_ety = raft_get_entry_from_idx(me_, ety_index);
-        if (existing_ety && existing_ety->term != ety->term)
+        int term;
+        int got = raft_get_entry_term(me_, ety_index, &term);
+        if (got && term != ety->term)
         {
             if (ety_index <= raft_get_commit_idx(me_))
             {
@@ -470,7 +486,7 @@ int raft_recv_appendentries(
                 goto out;
             break;
         }
-        else if (!existing_ety)
+        else if (!got && raft_get_current_idx(me_) < ety_index)
             break;
         r->current_idx = ety_index;
     }
@@ -527,15 +543,13 @@ static int __should_grant_vote(raft_server_private_t* me, msg_requestvote_t* vr)
 
     int current_idx = raft_get_current_idx((void*)me);
 
-    /* Our log is definitely not more up-to-date if it's empty! */
-    if (0 == current_idx)
+    int term;
+    int got = raft_get_entry_term((void*)me, current_idx, &term);
+    assert(got);
+    if (term < vr->last_log_term)
         return 1;
 
-    raft_entry_t* ety = raft_get_entry_from_idx((void*)me, current_idx);
-    if (ety->term < vr->last_log_term)
-        return 1;
-
-    if (vr->last_log_term == ety->term && current_idx <= vr->last_log_idx)
+    if (vr->last_log_term == term && current_idx <= vr->last_log_idx)
         return 1;
 
     return 0;
@@ -1023,12 +1037,31 @@ int raft_vote_for_nodeid(raft_server_t* me_, const int nodeid)
 int raft_msg_entry_response_committed(raft_server_t* me_,
                                       const msg_entry_response_t* r)
 {
-    raft_entry_t* ety = raft_get_entry_from_idx(me_, r->idx);
-    if (!ety)
-        return 0;
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+
+    int term;
+    int got = raft_get_entry_term(me_, r->idx, &term);
+    if (!got)
+    {
+        if (r->idx <= log_get_base(me->log))
+        {
+            /* The entry has been compacted. */
+            if (r->term == me->current_term)
+                /* The index is committed in this term, so it must be ours. */
+                return 1;
+            else
+                /* Impossible to know for sure. */
+                return -1;
+        }
+        else
+        {
+            /* The entry is not stored on this replica yet. */
+            return 0;
+        }
+    }
 
     /* entry from another leader has invalidated this entry message */
-    if (r->term != ety->term)
+    if (r->term != term)
         return -1;
     return r->idx <= raft_get_commit_idx(me_);
 }
@@ -1166,17 +1199,13 @@ int raft_get_first_entry_idx(raft_server_t* me_)
 
     assert(0 < raft_get_current_idx(me_));
 
-    if (me->snapshot_last_idx == 0)
-        return 1;
-
-    return me->snapshot_last_idx;
+    return log_get_base(me->log) + 1;
 }
 
 int raft_get_num_snapshottable_logs(raft_server_t *me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
-    if (raft_get_log_count(me_) <= 1)
-        return 0;
+    assert(log_get_base(me->log) <= raft_get_commit_idx(me_));
     return raft_get_commit_idx(me_) - log_get_base(me->log);
 }
 

--- a/tests/test_log.c
+++ b/tests/test_log.c
@@ -302,14 +302,17 @@ void TestLog_poll(CuTest * tc)
     memset(&e3, 0, sizeof(raft_entry_t));
 
     e1.id = 1;
+    e1.term = 1;
     CuAssertIntEquals(tc, 0, log_append_entry(l, &e1));
     CuAssertIntEquals(tc, 1, log_get_current_idx(l));
 
     e2.id = 2;
+    e2.term = 2;
     CuAssertIntEquals(tc, 0, log_append_entry(l, &e2));
     CuAssertIntEquals(tc, 2, log_get_current_idx(l));
 
     e3.id = 3;
+    e3.term = 3;
     CuAssertIntEquals(tc, 0, log_append_entry(l, &e3));
     CuAssertIntEquals(tc, 3, log_count(l));
     CuAssertIntEquals(tc, 3, log_get_current_idx(l));
@@ -318,6 +321,7 @@ void TestLog_poll(CuTest * tc)
     CuAssertIntEquals(tc, 0, log_poll(l, 1));
     CuAssertIntEquals(tc, 2, log_count(l));
     CuAssertIntEquals(tc, 1, log_get_base(l));
+    CuAssertIntEquals(tc, 1, log_get_base_term(l));
     CuAssertTrue(tc, NULL == log_get_at_idx(l, 1));
     CuAssertTrue(tc, NULL != log_get_at_idx(l, 2));
     CuAssertTrue(tc, NULL != log_get_at_idx(l, 3));
@@ -327,6 +331,7 @@ void TestLog_poll(CuTest * tc)
     CuAssertIntEquals(tc, 0, log_poll(l, 3));
     CuAssertIntEquals(tc, 0, log_count(l));
     CuAssertIntEquals(tc, 3, log_get_base(l));
+    CuAssertIntEquals(tc, 3, log_get_base_term(l));
     CuAssertTrue(tc, NULL == log_get_at_idx(l, 1));
     CuAssertTrue(tc, NULL == log_get_at_idx(l, 2));
     CuAssertTrue(tc, NULL == log_get_at_idx(l, 3));
@@ -379,12 +384,9 @@ void TestLog_load_from_snapshot(CuTest * tc)
 
     l = log_new();
     CuAssertIntEquals(tc, 0, log_get_current_idx(l));
-    CuAssertIntEquals(tc, 0, log_load_from_snapshot(l, 10, 5));
+    log_load_from_snapshot(l, 10, 5);
     CuAssertIntEquals(tc, 10, log_get_current_idx(l));
-
-    /* this is just a marker
-     * it should never be sent to any nodes because it is part of a snapshot */
-    CuAssertIntEquals(tc, 1, log_count(l));
+    CuAssertIntEquals(tc, 0, log_count(l));
 }
 
 void TestLog_load_from_snapshot_clears_log(CuTest * tc)
@@ -403,8 +405,8 @@ void TestLog_load_from_snapshot_clears_log(CuTest * tc)
     CuAssertIntEquals(tc, 2, log_count(l));
     CuAssertIntEquals(tc, 2, log_get_current_idx(l));
 
-    CuAssertIntEquals(tc, 0, log_load_from_snapshot(l, 10, 5));
-    CuAssertIntEquals(tc, 1, log_count(l));
+    log_load_from_snapshot(l, 10, 5);
+    CuAssertIntEquals(tc, 0, log_count(l));
     CuAssertIntEquals(tc, 10, log_get_current_idx(l));
 }
 

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -170,37 +170,6 @@ void TestRaft_leader_snapshot_end_fails_if_snapshot_not_in_progress(CuTest * tc)
     CuAssertIntEquals(tc, -1, raft_end_snapshot(r));
 }
 
-void TestRaft_leader_snapshot_begin_fails_if_less_than_2_logs_to_compact(CuTest * tc)
-{
-    raft_cbs_t funcs = {
-        .send_appendentries = __raft_send_appendentries,
-    };
-
-    void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
-
-    msg_entry_response_t cr;
-
-    raft_add_node(r, NULL, 1, 1);
-    raft_add_node(r, NULL, 2, 0);
-
-    /* I am the leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
-    CuAssertIntEquals(tc, 0, raft_get_log_count(r));
-
-    /* entry message */
-    msg_entry_t ety = {};
-    ety.id = 1;
-    ety.data.buf = "entry";
-    ety.data.len = strlen("entry");
-
-    /* receive entry */
-    raft_recv_entry(r, &ety, &cr);
-    raft_set_commit_idx(r, 1);
-    CuAssertIntEquals(tc, 1, raft_get_log_count(r));
-    CuAssertIntEquals(tc, -1, raft_begin_snapshot(r));
-}
-
 void TestRaft_leader_snapshot_end_succeeds_if_log_compacted(CuTest * tc)
 {
     raft_cbs_t funcs = {
@@ -352,7 +321,7 @@ void TestRaft_follower_load_from_snapshot(CuTest * tc)
     CuAssertIntEquals(tc, 0, raft_get_log_count(r));
     CuAssertIntEquals(tc, 0, raft_begin_load_snapshot(r, 5, 5));
     CuAssertIntEquals(tc, 0, raft_end_load_snapshot(r));
-    CuAssertIntEquals(tc, 1, raft_get_log_count(r));
+    CuAssertIntEquals(tc, 0, raft_get_log_count(r));
     CuAssertIntEquals(tc, 0, raft_get_num_snapshottable_logs(r));
     CuAssertIntEquals(tc, 5, raft_get_commit_idx(r));
     CuAssertIntEquals(tc, 5, raft_get_last_applied_idx(r));
@@ -392,7 +361,7 @@ void TestRaft_follower_load_from_snapshot_fails_if_already_loaded(CuTest * tc)
     CuAssertIntEquals(tc, 0, raft_get_log_count(r));
     CuAssertIntEquals(tc, 0, raft_begin_load_snapshot(r, 5, 5));
     CuAssertIntEquals(tc, 0, raft_end_load_snapshot(r));
-    CuAssertIntEquals(tc, 1, raft_get_log_count(r));
+    CuAssertIntEquals(tc, 0, raft_get_log_count(r));
     CuAssertIntEquals(tc, 0, raft_get_num_snapshottable_logs(r));
     CuAssertIntEquals(tc, 5, raft_get_commit_idx(r));
     CuAssertIntEquals(tc, 5, raft_get_last_applied_idx(r));


### PR DESCRIPTION
Although RAFT_LOGTYPE_SNAPSHOT entries make getting terms easy, they
require extra cares:

  - After a log is polled, it no longer has a RAFT_LOGTYPE_SNAPSHOT
    entry at its head. We could require log_poll to convert an existing
    entry into a RAFT_LOGTYPE_SNAPSHOT one, but that would either be
    hard to implement without a transactional storage or require a scan
    for RAFT_LOGTYPE_SNAPSHOT entries in the middle of a log when a
    replica starts.

  - When transferring entries or getting entry counts, we need to
    consider if the log head is a RAFT_LOGTYPE_SNAPSHOT entry or not.

It becomes simpler to think about if we get rid of RAFT_LOGTYPE_SNAPSHOT
and store the snapshot term separately. Getting a term will indeed need
to check if the index points at the snapshot, but that can easily be
hidden inside a common helper.

  - Allow compacting a single-entry log. Useful for testing purposes.

Signed-off-by: Li Wei <wei.g.li@intel.com>