### PR TITLE
DAOS-1021 log: Support batch offering

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -322,7 +322,7 @@ typedef int (
  *    memory pointed to in the raft_entry_data_t struct. This MUST be done if
  *    the memory is temporary.
  * @param[in] entry_idx The lower bound of the index range (ie. the index of entries[0])
- * @param[in] n_entries The number of entries in the range
+ * @param[in,out] n_entries The number of entries in the range
  * @return 0 on success */
 typedef int (
 *func_logentries_event_f
@@ -331,7 +331,7 @@ typedef int (
     void *user_data,
     raft_entry_t *entries,
     int entry_idx,
-    int n_entries
+    int *n_entries
     );
 
 /** Callback for saving changes to one log entry. See also
@@ -370,11 +370,11 @@ typedef struct
      * disk atomically. */
     func_persist_term_f persist_term;
 
-    /** Callback for adding an entry to the log
+    /** Callback for adding entries to the log
      * For safety reasons this callback MUST flush the change to disk.
      * Return 0 on success.
      * Return RAFT_ERR_SHUTDOWN if you want the server to shutdown. */
-    func_logentry_event_f log_offer;
+    func_logentries_event_f log_offer;
 
     /** Callback for removing entries from the log head
      * For safety reasons this callback MUST flush the change to disk.
@@ -714,14 +714,15 @@ int raft_set_current_term(raft_server_t* me, const int term);
  * @param[in] commit_idx The new commit index. */
 void raft_set_commit_idx(raft_server_t* me, int commit_idx);
 
-/** Add an entry to the server's log.
+/** Add entries to the server's log.
  * This should be used to reload persistent state, ie. the commit log.
- * @param[in] ety The entry to be appended
+ * @param[in] entries List of entries to be appended
+ * @param[in,out] n Number of entries to append / successfully appended
  * @return
  *  0 on success;
  *  RAFT_ERR_SHUTDOWN server should shutdown
  *  RAFT_ERR_NOMEM memory allocation failure */
-int raft_append_entry(raft_server_t* me, raft_entry_t* ety);
+int raft_append_entries(raft_server_t* me, raft_entry_t* entries, int *n);
 
 /** Confirm if a msg_entry_response has been committed.
  * @param[in] r The response we want to check */

--- a/include/raft_log.h
+++ b/include/raft_log.h
@@ -14,11 +14,10 @@ void log_free(log_t* me_);
 void log_clear(log_t* me_);
 
 /**
- * Add entry to log.
- * Don't add entry if we've already added this entry (based off ID)
- * Don't add entries with ID=0 
- * @return 0 if unsucessful; 1 otherwise */
-int log_append_entry(log_t* me_, raft_entry_t* c);
+ * Add 'n' entries to the log with valid (positive, non-zero) IDs
+ * that haven't already been added and save the number of successfully
+ * appended entries in 'n' */
+int log_append(log_t* me_, raft_entry_t* entries, int *n);
 
 /**
  * @return number of entries held within log */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -100,7 +100,7 @@ int raft_apply_entry(raft_server_t* me_);
  * Appends entry using the current term.
  * Note: we make the assumption that current term is up-to-date
  * @return 0 if unsuccessful */
-int raft_append_entry(raft_server_t* me_, raft_entry_t* c);
+int raft_append_entries(raft_server_t* me, raft_entry_t* entries, int *n);
 
 void raft_set_last_applied_idx(raft_server_t* me, int idx);
 
@@ -126,7 +126,8 @@ void raft_node_set_has_sufficient_logs(raft_node_t* me_);
 
 int raft_votes_is_majority(const int nnodes, const int nvotes);
 
-void raft_offer_log(raft_server_t* me_, raft_entry_t* ety, const int idx);
+void raft_offer_log(raft_server_t* me_, raft_entry_t* entries,
+                    const int n_entries, const int idx);
 
 void raft_pop_log(raft_server_t* me_, raft_entry_t* ety, const int idx);
 

--- a/tests/test_log.c
+++ b/tests/test_log.c
@@ -25,8 +25,9 @@ static int __logentry_get_node_id(
 static int __log_offer(
     raft_server_t* raft,
     void *user_data,
-    raft_entry_t *entry,
-    int entry_idx
+    raft_entry_t *entries,
+    int entry_idx,
+    int *n_entries
     )
 {
     CuAssertIntEquals((CuTest*)raft, 1, entry_idx);
@@ -60,6 +61,12 @@ raft_cbs_t funcs = {
     .log_pop = __log_pop,
     .log_get_node_id = __logentry_get_node_id
 };
+
+static int log_append_entry(log_t* me_, raft_entry_t* ety)
+{
+    int k = 1;
+    return log_append(me_, ety, &k);
+}
 
 void* __set_up()
 {

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -71,6 +71,12 @@ static int __raft_send_appendentries_capture(raft_server_t* raft,
 /*     .persist_vote = __raft_persist_vote, */
 /* }; */
 
+static int raft_append_entry(raft_server_t* me_, raft_entry_t* ety)
+{
+    int k = 1;
+    return raft_append_entries(me_, ety, &k);
+}
+
 static int max_election_timeout(int election_timeout)
 {
 	return 2 * election_timeout;


### PR DESCRIPTION
Support appending multiple entries to the end of the log.
Increase capacity of the log buffer exponentially by a factor
of two at a time, enough to ensure that there is enough to
append the given number of entries.

Also eliminated memcpy loop; instead call memcpy at the most
twice for copying existing entries to the newly allocated buffer.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@intel.com>