### PR TITLE
DAOS-1046 log: Support batch popping

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -382,11 +382,12 @@ typedef struct
      *  time to free the memory. */
     func_logentries_event_f log_poll;
 
-    /** Callback for removing the youngest entry from the log
+    /** Callback for removing entries from the tail of the log in
+     * descending order.
      * For safety reasons this callback MUST flush the change to disk.
      * @note If memory was malloc'd in log_offer then this should be the right
      *  time to free the memory. */
-    func_logentry_event_f log_pop;
+    func_logentries_event_f log_pop;
 
     /** Callback for determining which node this configuration log entry
      * affects. This call only applies to configuration change log entries.

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -129,7 +129,8 @@ int raft_votes_is_majority(const int nnodes, const int nvotes);
 void raft_offer_log(raft_server_t* me_, raft_entry_t* entries,
                     const int n_entries, const int idx);
 
-void raft_pop_log(raft_server_t* me_, raft_entry_t* ety, const int idx);
+void raft_pop_log(raft_server_t* me_, raft_entry_t* entries,
+                    const int n_entries, const int idx);
 
 int raft_get_num_snapshottable_logs(raft_server_t* me_);
 

--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -54,19 +54,21 @@ static int __ensurecapacity(log_private_t * me, int n)
     if (!temp)
         return RAFT_ERR_NOMEM;
 
-
-    if (me->front + me->count <= me->size)
+    if (0 < me->count)
     {
-        memcpy(&temp[0], &me->entries[me->front],
-               me->count * sizeof(raft_entry_t));
-    }
-    else if (me->count > 0)
-    {
-        int index = me->size - me->front;
-        memcpy(&temp[0], &me->entries[me->front],
-               index * sizeof(raft_entry_t));
-        memcpy(&temp[index], &me->entries[0],
-               (me->count - index) * sizeof(raft_entry_t));
+        int k = me->size - me->front;
+        if (me->count <= k)
+        {
+            memcpy(&temp[0], &me->entries[me->front],
+                   sizeof(raft_entry_t) * me->count);
+        }
+        else
+        {
+            memcpy(&temp[0], &me->entries[me->front],
+                   sizeof(raft_entry_t) * k);
+            memcpy(&temp[k], &me->entries[0],
+                   sizeof(raft_entry_t) * (me->count - k));
+        }
     }
 
     /* clean up old entries */

--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -28,7 +28,7 @@ typedef struct
     int count;
 
     /* position of the queue */
-    int front, back;
+    int front;
 
     /* we compact the log, and thus need to increment the Base Log Index */
     int base;
@@ -39,12 +39,6 @@ typedef struct
     raft_cbs_t *cb;
     void* raft;
 } log_private_t;
-
-static int mod(int a, int b)
-{
-    int r = a % b;
-    return r < 0 ? r + b : r;
-}
 
 static int __ensurecapacity(log_private_t * me, int n)
 {
@@ -61,16 +55,18 @@ static int __ensurecapacity(log_private_t * me, int n)
         return RAFT_ERR_NOMEM;
 
 
-    if (me->front < me->back)
+    if (me->front + me->count <= me->size)
     {
         memcpy(&temp[0], &me->entries[me->front],
-               sizeof(raft_entry_t) * (me->back - me->front));
+               me->count * sizeof(raft_entry_t));
     }
     else if (me->count > 0)
     {
-        int i = me->size - me->front;
-        memcpy(&temp[0], &me->entries[me->front], i * sizeof(raft_entry_t));
-        memcpy(&temp[i], &me->entries[0], me->back * sizeof(raft_entry_t));
+        int index = me->size - me->front;
+        memcpy(&temp[0], &me->entries[me->front],
+               index * sizeof(raft_entry_t));
+        memcpy(&temp[index], &me->entries[0],
+               (me->count - index) * sizeof(raft_entry_t));
     }
 
     /* clean up old entries */
@@ -79,7 +75,6 @@ static int __ensurecapacity(log_private_t * me, int n)
     me->size = newsize;
     me->entries = temp;
     me->front = 0;
-    me->back = me->count;
     return 0;
 }
 
@@ -140,7 +135,6 @@ void log_clear(log_t* me_)
 {
     log_private_t* me = (log_private_t*)me_;
     me->count = 0;
-    me->back = 0;
     me->front = 0;
     me->base = 0;
 }
@@ -212,9 +206,10 @@ int log_append(log_t* me_, raft_entry_t* ety, int *n)
 
     for (i = 0; i < *n; )
     {
-        raft_entry_t *ptr = &me->entries[me->back];
         int idx = me->base + me->count + 1;
         int k = batch_up(me, idx, *n - i);
+        int start = subscript(me, me->base + me->count + 1);
+        raft_entry_t *ptr = &me->entries[start];
         int batch_size = k;
         memcpy(ptr, &ety[i], k * sizeof(raft_entry_t));
         if (me->cb && me->cb->log_offer)
@@ -223,7 +218,6 @@ int log_append(log_t* me_, raft_entry_t* ety, int *n)
         if (k > 0)
         {
             me->count += k;
-            me->back = mod(me->back + k, me->size);
             i += k;
             raft_offer_log(me->raft, ptr, k, idx);
         }
@@ -248,7 +242,8 @@ int log_delete(log_t* me_, int idx)
     {
         int k = batch_down(me, me->base + me->count,
                                me->base + me->count - idx + 1);
-        raft_entry_t *ptr = &me->entries[me->back - 1 - k];
+        int start = subscript(me, me->base + me->count - k + 1);
+        raft_entry_t *ptr = &me->entries[start];
         int batch_size = k;
         if (me->cb && me->cb->log_pop)
             e = me->cb->log_pop(me->raft, raft_get_udata(me->raft),
@@ -256,7 +251,6 @@ int log_delete(log_t* me_, int idx)
         if (k > 0)
         {
             raft_pop_log(me->raft, ptr, k, idx);
-            me->back = mod(me->back - k, me->size);
             me->count -= k;
         }
         if (0 != e)
@@ -283,7 +277,8 @@ int log_poll(log_t* me_, int idx)
                                  &me->entries[me->front], me->base + 1, &k);
         if (k > 0)
         {
-            me->front = mod(me->front + k, me->size);
+            me->front += k;
+            me->front %= me->size;
             me->count -= k;
             me->base += k;
         }
@@ -301,11 +296,7 @@ raft_entry_t *log_peektail(log_t * me_)
 
     if (0 == me->count)
         return NULL;
-
-    if (0 == me->back)
-        return &me->entries[me->size - 1];
-    else
-        return &me->entries[me->back - 1];
+    return &me->entries[subscript(me, me->base + me->count)];
 }
 
 void log_empty(log_t * me_)
@@ -313,7 +304,6 @@ void log_empty(log_t * me_)
     log_private_t* me = (log_private_t*)me_;
 
     me->front = 0;
-    me->back = 0;
     me->count = 0;
 }
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1133,14 +1133,14 @@ void raft_pop_log(raft_server_t* me_, raft_entry_t* entries,
     if (me == NULL || entries == NULL)
         return;
 
-    for (i = 0; i < n_entries; i++) {
-        raft_entry_t *ety = &entries[-i];
+    for (i = n_entries - 1; i >= 0; --i) {
+        raft_entry_t *ety = &entries[i];
 
         if (idx - i <= me->voting_cfg_change_log_idx)
             me->voting_cfg_change_log_idx = -1;
 
         if (!raft_entry_is_cfg_change(ety))
-            return;
+            continue;
 
         int node_id = me->cb.log_get_node_id(me_, raft_get_udata(me_),
                                              ety, idx);

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1124,54 +1124,53 @@ void raft_offer_log(raft_server_t* me_, raft_entry_t* entries,
     }
 }
 
-void raft_pop_log(raft_server_t* me_, raft_entry_t* ety, const int idx)
+void raft_pop_log(raft_server_t* me_, raft_entry_t* entries,
+                    const int n_entries, const int idx)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
+    int i;
 
-    if (me == NULL || ety == NULL)
+    if (me == NULL || entries == NULL)
         return;
 
-    if (!raft_entry_is_cfg_change(ety))
-        return;
+    for (i = 0; i < n_entries; i++) {
+        raft_entry_t *ety = &entries[-i];
 
-    int node_id = me->cb.log_get_node_id(me_, raft_get_udata(me_), ety, idx);
+        if (idx - i <= me->voting_cfg_change_log_idx)
+            me->voting_cfg_change_log_idx = -1;
 
-    switch (ety->type)
-    {
-        case RAFT_LOGTYPE_DEMOTE_NODE:
-            {
-            raft_node_t* node = raft_get_node(me_, node_id);
-            raft_node_set_voting(node, 1);
-            }
-            break;
+        if (!raft_entry_is_cfg_change(ety))
+            return;
 
-        case RAFT_LOGTYPE_REMOVE_NODE:
-            {
-            raft_node_t* node = raft_get_node(me_, node_id);
-            raft_node_set_active(node, 1);
-            }
-            break;
+        int node_id = me->cb.log_get_node_id(me_, raft_get_udata(me_),
+                                             ety, idx);
+        raft_node_t* node = raft_get_node(me_, node_id);
+        int is_self = node_id == raft_get_nodeid(me_);
 
-        case RAFT_LOGTYPE_ADD_NONVOTING_NODE:
-            {
-            int is_self = node_id == raft_get_nodeid(me_);
-            raft_node_t* node = raft_get_node(me_, node_id);
-            raft_remove_node(me_, node);
-            if (is_self)
+        switch (ety->type)
+        {
+            case RAFT_LOGTYPE_DEMOTE_NODE:
+                raft_node_set_voting(node, 1);
+                break;
+
+            case RAFT_LOGTYPE_REMOVE_NODE:
+                raft_node_set_active(node, 1);
+                break;
+
+            case RAFT_LOGTYPE_ADD_NONVOTING_NODE:
+                raft_remove_node(me_, node);
+                if (is_self)
+                    assert(0);
+                break;
+
+            case RAFT_LOGTYPE_ADD_NODE:
+                raft_node_set_voting(node, 0);
+                break;
+
+            default:
                 assert(0);
-            }
-            break;
-
-        case RAFT_LOGTYPE_ADD_NODE:
-            {
-            raft_node_t* node = raft_get_node(me_, node_id);
-            raft_node_set_voting(node, 0);
-            }
-            break;
-
-        default:
-            assert(0);
-            break;
+                break;
+        }
     }
 }
 

--- a/tests/test_log.c
+++ b/tests/test_log.c
@@ -38,12 +38,17 @@ static int __log_pop(
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entry,
-    int entry_idx
+    int entry_idx,
+    int *n_entries
     )
 {
-    raft_entry_t* copy = malloc(sizeof(*entry));
-    memcpy(copy, entry, sizeof(*entry));
-    llqueue_offer(user_data, copy);
+    raft_entry_t* copy = malloc(*n_entries * sizeof(*entry));
+    int i;
+    for (i = 0; i < *n_entries; i++)
+    {
+        memcpy(copy, entry--, sizeof(*copy));
+        llqueue_offer(user_data, copy++);
+    }
     return 0;
 }
 
@@ -51,9 +56,11 @@ static int __log_pop_failing(
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entry,
-    int entry_idx
+    int entry_idx,
+    int *n_entries
     )
 {
+    *n_entries = 0;
     return -1;
 }
 

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -1506,12 +1506,16 @@ static int __raft_log_pop_error(
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entry,
-    int entry_idx)
+    int entry_idx,
+    int *n_entries)
 {
     __raft_error_t *error = user_data;
 
-    if (__RAFT_LOG_POP_ERR == error->type && entry_idx == error->idx)
+    if (__RAFT_LOG_POP_ERR == error->type && entry_idx <= error->idx
+        && error->idx < (entry_idx + *n_entries)) {
+        *n_entries = error->idx - entry_idx;
         return RAFT_ERR_NOMEM;
+    }
     return 0;
 }
 


### PR DESCRIPTION
Support for deleting multiple entries from the tail of the log 
starting from the youngest entry. This order is important in
order to backtrack transitions to the state machine for correctly
restoring the state right before the oldest entry that is deleted.
Also, remove the redundant field 'back' used to track log entries.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@intel.com>