### PR TITLE
DAOS-1197 test: Add files created by testing to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 *.o
 *.gcno
+*.gcda
+tests/main_test.c
+tests_main
+CLinkedListQueue
+raft_server.c.gcov
 *~
 libcraft.so
 libcraft.a


### PR DESCRIPTION
To avoid leaving the daos submodule dirty when running raft
tests

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>