### PR TITLE
DAOS-1257 Separate the build and running of tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,11 @@ shared: $(OBJECTS)
 static: $(OBJECTS)
 	ar -r libraft.a $(OBJECTS)
 
+tests_main: src/raft_server.c src/raft_server_properties.c src/raft_log.c src/raft_node.c $(TEST_DIR)/main_test.c $(TEST_DIR)/test_server.c $(TEST_DIR)/test_node.c $(TEST_DIR)/test_log.c $(TEST_DIR)/test_snapshotting.c $(TEST_DIR)/test_scenario.c $(TEST_DIR)/mock_send_functions.c $(TEST_DIR)/CuTest.c $(LLQUEUE_DIR)/linked_list_queue.c
+	$(CC) $(CFLAGS) -o $@ $^
+
 .PHONY: tests
-tests: src/raft_server.c src/raft_server_properties.c src/raft_log.c src/raft_node.c $(TEST_DIR)/main_test.c $(TEST_DIR)/test_server.c $(TEST_DIR)/test_node.c $(TEST_DIR)/test_log.c $(TEST_DIR)/test_snapshotting.c $(TEST_DIR)/test_scenario.c $(TEST_DIR)/mock_send_functions.c $(TEST_DIR)/CuTest.c $(LLQUEUE_DIR)/linked_list_queue.c
-	$(CC) $(CFLAGS) -o tests_main $^
+tests: tests_main
 	./tests_main
 	gcov raft_server.c
 


### PR DESCRIPTION
Currently in the raft Makefile the tests target both builds the test
tool and runs it.  This is sub-optimal for workflows where building and
testing happen separately.

It would be better to simply separate out the building of the tool from
the actual running of the tests.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>