### PR TITLE
DAOS-1333 build: Add -Wshadow to raft build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GCOV_CCFLAGS = -fprofile-arcs -ftest-coverage
 SHELL  = /bin/bash
 CFLAGS += -Iinclude -Werror -Werror=return-type -Werror=uninitialized -Wcast-align \
 	  -Wno-pointer-sign -fno-omit-frame-pointer -fno-common -fsigned-char \
-	  -Wunused-variable \
+	  -Wunused-variable -Wshadow \
 	  $(GCOV_CCFLAGS) -I$(LLQUEUE_DIR) -Iinclude -g -O2 -fPIC
 
 UNAME := $(shell uname)

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -357,11 +357,11 @@ int raft_recv_appendentries_response(raft_server_t* me_,
             int i, votes = 1;
             for (i = 0; i < me->num_nodes; i++)
             {
-                raft_node_t* node = me->nodes[i];
-                if (me->node != node &&
-                    raft_node_is_active(node) &&
-                    raft_node_is_voting(node) &&
-                    point <= raft_node_get_match_idx(node))
+                raft_node_t* tmpnode = me->nodes[i];
+                if (me->node != tmpnode &&
+                    raft_node_is_active(tmpnode) &&
+                    raft_node_is_voting(tmpnode) &&
+                    point <= raft_node_get_match_idx(tmpnode))
                 {
                     votes++;
                 }
@@ -1235,9 +1235,9 @@ void raft_offer_log(raft_server_t* me_, raft_entry_t* entries,
                     }
                     else if (!node)
                     {
-                        raft_node_t* node = raft_add_non_voting_node(
+                        raft_node_t* tmpnode = raft_add_non_voting_node(
                                                 me_, NULL, node_id, is_self);
-                        assert(node);
+                        assert(tmpnode);
                     }
                 }
                 break;


### PR DESCRIPTION
It's not good coding practice to use the same name for temporaries and adding -Wshadow enables some optimization in macros (such as D_DEBUG in DAOS).  Also, since we build raft using the SConscript with DAOS settings, these warnings block DAOS from adding -Wshadow to fix and prevent its own issues.