### PR TITLE
DAOS-1148 raft: Fixes for possible null dereferencing

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -50,16 +50,7 @@ typedef enum {
     RAFT_LOGTYPE_ADD_NODE,
     /**
      * Membership change.
-     * Nodes become demoted when we want to remove them from the cluster.
-     * Demoted nodes can't take part in voting or start elections.
-     * Demoted nodes become inactive, as per raft_node_is_active.
-     */
-    RAFT_LOGTYPE_DEMOTE_NODE,
-    /**
-     * Membership change.
-     * The node is removed from the cluster.
-     * This happens after the node has been demoted.
-     * Removing nodes is a 2 step process: first demote, then remove.
+     * Remove a node from the cluster.
      */
     RAFT_LOGTYPE_REMOVE_NODE,
     /**
@@ -843,7 +834,7 @@ int raft_node_has_sufficient_logs(raft_node_t* me_);
  * @return
  *  0 on success;
  *  RAFT_ERR_SHUTDOWN when server MUST shutdown */
-int raft_apply_all(raft_server_t* me_);
+int raft_apply(raft_server_t* me_);
 
 /** Become leader
  * WARNING: this is a dangerous function call. It could lead to your cluster

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -92,11 +92,6 @@ int raft_send_appendentries(raft_server_t* me, raft_node_t* node);
 int raft_send_appendentries_all(raft_server_t* me_);
 
 /**
- * Apply entry at lastApplied + 1. Entry becomes 'committed'.
- * @return 1 if entry committed, 0 otherwise */
-int raft_apply_entry(raft_server_t* me_);
-
-/**
  * Appends entry using the current term.
  * Note: we make the assumption that current term is up-to-date
  * @return 0 if unsuccessful */

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -383,7 +383,7 @@ void TestRaft_server_wont_apply_entry_if_we_dont_have_entry_to_apply(CuTest* tc)
     raft_set_commit_idx(r, 0);
     raft_set_last_applied_idx(r, 0);
 
-    raft_apply_entry(r);
+    raft_apply(r);
     CuAssertTrue(tc, 0 == raft_get_last_applied_idx(r));
     CuAssertTrue(tc, 0 == raft_get_commit_idx(r));
 }
@@ -397,7 +397,7 @@ void TestRaft_server_wont_apply_entry_if_there_isnt_a_majority(CuTest* tc)
     raft_set_commit_idx(r, 0);
     raft_set_last_applied_idx(r, 0);
 
-    raft_apply_entry(r);
+    raft_apply(r);
     CuAssertTrue(tc, 0 == raft_get_last_applied_idx(r));
     CuAssertTrue(tc, 0 == raft_get_commit_idx(r));
 
@@ -408,7 +408,7 @@ void TestRaft_server_wont_apply_entry_if_there_isnt_a_majority(CuTest* tc)
     ety.data.buf = str;
     ety.data.len = 3;
     raft_append_entry(r, &ety);
-    raft_apply_entry(r);
+    raft_apply(r);
     /* Not allowed to be applied because we haven't confirmed a majority yet */
     CuAssertTrue(tc, 0 == raft_get_last_applied_idx(r));
     CuAssertTrue(tc, 0 == raft_get_commit_idx(r));
@@ -464,7 +464,7 @@ void TestRaft_server_apply_entry_increments_last_applied_idx(CuTest* tc)
     ety.data.len = 3;
     raft_append_entry(r, &ety);
     raft_set_commit_idx(r, 1);
-    raft_apply_entry(r);
+    raft_apply(r);
     CuAssertTrue(tc, 1 == raft_get_last_applied_idx(r));
 }
 
@@ -2485,7 +2485,7 @@ void TestRaft_leader_responds_to_entry_msg_when_entry_is_committed(CuTest * tc)
     CuAssertTrue(tc, 1 == raft_get_log_count(r));
 
     /* trigger response through commit */
-    raft_apply_entry(r);
+    raft_apply(r);
 }
 
 void TestRaft_non_leader_recv_entry_msg_fails(CuTest * tc)
@@ -3095,10 +3095,6 @@ void TestRaft_leader_recv_appendentries_response_do_not_increase_commit_idx_beca
     CuAssertIntEquals(tc, 0, raft_get_commit_idx(r));
     raft_recv_appendentries_response(r, raft_get_node(r, 3), &aer);
     CuAssertIntEquals(tc, 3, raft_get_commit_idx(r));
-    raft_periodic(r, 1);
-    CuAssertIntEquals(tc, 1, raft_get_last_applied_idx(r));
-    raft_periodic(r, 1);
-    CuAssertIntEquals(tc, 2, raft_get_last_applied_idx(r));
     raft_periodic(r, 1);
     CuAssertIntEquals(tc, 3, raft_get_last_applied_idx(r));
 }

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -175,7 +175,7 @@ void TestRaft_leader_will_not_apply_entry_if_snapshot_is_in_progress(CuTest * tc
     CuAssertIntEquals(tc, 0, raft_begin_snapshot(r, 1));
     CuAssertIntEquals(tc, 1, raft_get_last_applied_idx(r));
     raft_set_commit_idx(r, 2);
-    CuAssertIntEquals(tc, -1, raft_apply_entry(r));
+    CuAssertIntEquals(tc, 0, raft_apply(r));
     CuAssertIntEquals(tc, 1, raft_get_last_applied_idx(r));
 }
 
@@ -323,7 +323,7 @@ void TestRaft_joinee_needs_to_get_snapshot(CuTest * tc)
 
     CuAssertIntEquals(tc, 0, raft_begin_snapshot(r, 1));
     CuAssertIntEquals(tc, 1, raft_get_last_applied_idx(r));
-    CuAssertIntEquals(tc, -1, raft_apply_entry(r));
+    CuAssertIntEquals(tc, 0, raft_apply(r));
     CuAssertIntEquals(tc, 1, raft_get_last_applied_idx(r));
 }
 


### PR DESCRIPTION
1. Added checks for pointers returned by getter functions for
   potential null values.
2. Removed a redundant assignment.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@intel.com>