### PR TITLE
DAOS-1876 build: Regenerate object files if headers change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ all: static shared
 $(BUILDDIR):
 	mkdir -p $@
 
-$(BUILDDIR)/%.o: %.c | $(BUILDDIR)
+$(BUILDDIR)/%.o: %.c $(wildcard include/*.h) | $(BUILDDIR)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 clinkedlistqueue:


### PR DESCRIPTION
Currently the Makefile recompiles object files only if the
corresponding source file has changed. We have run into a scenario
where a type definition was updated in a header causing different
object files to end up with multiple definitions of that same type
and resulting in memory corruption / segfaults.

Ideally, recompilation should occur only when an included header file
changes. But the simpler approach is to force recompilation when any
of the header files have changed; this works well for small projects.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@intel.com>