### PR TITLE
DAOS-1627 raft: Membership Changes

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -744,6 +744,10 @@ int raft_get_request_timeout(raft_server_t* me);
 int raft_get_last_applied_idx(raft_server_t* me);
 
 /**
+ * Set index of the last applied entry */
+void raft_set_last_applied_idx(raft_server_t* me_, int idx);
+
+/**
  * @return the node's next index */
 int raft_node_get_next_idx(raft_node_t* node);
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -112,11 +112,21 @@ raft_node_t* raft_node_new(void* udata, int id);
 
 void raft_node_free(raft_node_t* me_);
 
+void raft_node_set_server(raft_node_t* me_, raft_server_t *server);
+
 void raft_node_set_next_idx(raft_node_t* node, int nextIdx);
 
 void raft_node_set_match_idx(raft_node_t* node, int matchIdx);
 
 int raft_node_get_match_idx(raft_node_t* me_);
+
+void raft_node_set_offered_idx(raft_node_t* me_, int offeredIdx);
+
+int raft_node_get_offered_idx(raft_node_t* me_);
+
+void raft_node_set_applied_idx(raft_node_t* me_, int appliedIdx);
+
+int raft_node_get_applied_idx(raft_node_t* me_);
 
 void raft_node_vote_for_me(raft_node_t* me_, const int vote);
 
@@ -127,10 +137,10 @@ void raft_node_set_has_sufficient_logs(raft_node_t* me_);
 int raft_votes_is_majority(const int nnodes, const int nvotes);
 
 void raft_offer_log(raft_server_t* me_, raft_entry_t* entries,
-                    const int n_entries, const int idx);
+                    int n_entries, int idx);
 
 void raft_pop_log(raft_server_t* me_, raft_entry_t* entries,
-                    const int n_entries, const int idx);
+                  int n_entries, int idx);
 
 int raft_get_num_snapshottable_logs(raft_server_t* me_);
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -933,7 +933,6 @@ int raft_apply_entry(raft_server_t* me_)
     int node_id = me->cb.log_get_node_id(me_, raft_get_udata(me_), ety, log_idx);
     raft_node_t* node = raft_get_node(me_, node_id);
     assert(node);
-    raft_node_set_applied_idx(node, log_idx);
 
     switch (ety->type) {
         case RAFT_LOGTYPE_ADD_NODE:
@@ -947,9 +946,10 @@ int raft_apply_entry(raft_server_t* me_)
             if (raft_node_get_offered_idx(node) == log_idx)
                 raft_remove_node(me_, node);
             break;
-        default:
-            break;
     }
+    raft_node_set_applied_idx(node, log_idx);
+    if (raft_node_get_offered_idx(node) == log_idx)
+        raft_node_set_offered_idx(node, -1);
 
     return 0;
 }
@@ -1236,18 +1236,11 @@ void raft_offer_log(raft_server_t* me_, raft_entry_t* entries,
             continue;
 
         if (raft_entry_is_voting_cfg_change(ety))
-            me->voting_cfg_change_log_idx = raft_get_current_idx(me_);
+            me->voting_cfg_change_log_idx = idx + i;
 
         int node_id = me->cb.log_get_node_id(me_, raft_get_udata(me_),
                                              ety, idx + i);
         raft_node_t* node = raft_get_node(me_, node_id);
-        int is_self = node_id == raft_get_nodeid(me_);
-
-        if (!node && ety->type == RAFT_LOGTYPE_ADD_NONVOTING_NODE)
-        {
-            node = raft_add_non_voting_node_internal(me_, ety, NULL,
-                                                     node_id, is_self);
-        }
         assert(node);
         raft_node_set_offered_idx(node, idx + i);
     }
@@ -1328,9 +1321,22 @@ int raft_begin_snapshot(raft_server_t *me_, int idx)
 int raft_end_snapshot(raft_server_t *me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
+    int i;
 
     if (!me->snapshot_in_progress || me->snapshot_last_idx == 0)
         return -1;
+
+    for (i = 0; i < me->num_nodes; i++)
+    {
+        raft_node_t* node = me->nodes[i];
+        /*
+         * Reset applied idx to -1 if voting not committed before polling
+         * NB: If addition is not committed this node would've been deleted.
+         */
+        if (raft_node_get_applied_idx(node) <= me->snapshot_last_idx
+            && !raft_node_is_voting_committed(node))
+                raft_node_set_applied_idx(node, -1);
+    }
 
     int e = log_poll(me->log, me->snapshot_last_idx);
     if (e != 0)

--- a/tests/test_node.c
+++ b/tests/test_node.c
@@ -10,10 +10,10 @@
 #include "raft_log.h"
 #include "raft_private.h"
 
-void TestRaft_is_voting_by_default(CuTest * tc)
+void TestRaft_is_non_voting_by_default(CuTest * tc)
 {
     raft_node_t *p = raft_node_new((void*)1, 1);
-    CuAssertTrue(tc, raft_node_is_voting(p));
+    CuAssertTrue(tc, !raft_node_is_voting(p));
 }
 
 void TestRaft_node_set_nextIdx(CuTest * tc)

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -83,6 +83,14 @@ static int __raft_log_offer(raft_server_t* raft,
         int entry_idx,
         int *n_entries)
 {
+    int i;
+    for (i = 0; i < *n_entries; ++i)
+    {
+        raft_entry_t *ety = &entries[i];
+
+        if (ety->type == RAFT_LOGTYPE_ADD_NONVOTING_NODE)
+            raft_add_non_voting_node(raft, NULL, atoi(ety->data.buf), false);
+    }
     return 0;
 }
 


### PR DESCRIPTION
Instead of using flags for tracking the status of a node, it can be
interpreted from the most recent log entries affecting a node.  Making
repeated changes to the flags and keeping track of them proves to be
error prone when there are a series of membership changes. This
solution also renders a lot of code redundant, e.g. in raft_offer_log
and raft_pop_log and allows for a more elegant implementation.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@intel.com>