### PR TITLE
DAOS-2177 raft: Unit test fails in CI

### DIFF
--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -2622,7 +2622,7 @@ void TestRaft_leader_sends_appendentries_with_NextIdx_when_PrevIdx_gt_NextIdx(
     /* i'm leader */
     raft_set_state(r, RAFT_STATE_LEADER);
 
-    raft_entry_t etys[3];
+    raft_entry_t etys[3] = {};
     int i;
     for (i = 0; i < 3; i++)
     {


### PR DESCRIPTION
A raft unit test fails with a segmentation fault because the local
stack variable of 'raft_entry_t' type is not being initialized. It may
happen that the 'type' field ends up with a value from the enumeration
'raft_logtype_e' and gets incorrectly processed by Raft as a change in
the membership, which leads to the segfault.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@intel.com>