### PR TITLE
DAOS-2181 raft: Avoid passing raft_node_t pointers around

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -732,10 +732,6 @@ int raft_is_leader(raft_server_t* me);
 int raft_is_candidate(raft_server_t* me);
 
 /**
- * @return 1 if node ID matches the server; 0 otherwise */
-int raft_is_self(raft_server_t* me_, raft_node_t* node);
-
-/**
  * @return currently elapsed timeout in milliseconds */
 int raft_get_timeout_elapsed(raft_server_t* me);
 

--- a/include/raft.h
+++ b/include/raft.h
@@ -732,6 +732,10 @@ int raft_is_leader(raft_server_t* me);
 int raft_is_candidate(raft_server_t* me);
 
 /**
+ * @return 1 if node ID matches the server; 0 otherwise */
+int raft_is_self(raft_server_t* me_, raft_node_t* node);
+
+/**
  * @return currently elapsed timeout in milliseconds */
 int raft_get_timeout_elapsed(raft_server_t* me);
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -52,8 +52,8 @@ typedef struct {
     int election_timeout_rand;
     int request_timeout;
 
-    /* what this node thinks is the node ID of the current leader, or NULL if
-     * there isn't a known current leader. */
+    /* what this node thinks is the node ID of the current leader,
+     * or -1 if there isn't a known current leader. */
     int leader_id;
 
     /* my node ID */
@@ -107,6 +107,10 @@ void raft_set_last_applied_idx(raft_server_t* me, int idx);
 void raft_set_state(raft_server_t* me_, int state);
 
 int raft_get_state(raft_server_t* me_);
+
+/**
+ * @return 1 if node ID matches the server; 0 otherwise */
+int raft_is_self(raft_server_t* me_, raft_node_t* node);
 
 raft_node_t* raft_node_new(void* udata, int id);
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -54,14 +54,14 @@ typedef struct {
 
     /* what this node thinks is the node ID of the current leader, or NULL if
      * there isn't a known current leader. */
-    raft_node_t* current_leader;
+    int leader_id;
+
+    /* my node ID */
+    int node_id;
 
     /* callbacks */
     raft_cbs_t cb;
     void* udata;
-
-    /* my node ID */
-    raft_node_t* node;
 
     /* the log which has a voting cfg change, otherwise -1 */
     int voting_cfg_change_log_idx;

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -194,5 +194,5 @@ int raft_node_is_addition_committed(raft_node_t* me_)
 int raft_node_get_id(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
-    return me->id;
+    return (NULL == me) ? -1 : me->id;
 }


### PR DESCRIPTION
Passing around pointers to raft_node_t objects and referencing them
all over the code results in errors and crashes due to dangling
pointers when nodes are removed. It is safer to use the node ID to
look up a node from the server's node list.

In the future, it would be ideal to introduce reference counting and
thread safety to Raft as a whole and the node list in particular.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@intel.com>