### PR TITLE
DAOS-4023 raft: fix build issue when pulling CLinkedListQueue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ $(BUILDDIR)/%.o: %.c $(wildcard include/*.h) | $(BUILDDIR)
 clinkedlistqueue:
 	mkdir -p $(LLQUEUE_DIR)/.git
 	git --git-dir=$(LLQUEUE_DIR)/.git init 
-	pushd $(LLQUEUE_DIR); git pull http://github.com/willemt/CLinkedListQueue; popd
+	pushd $(LLQUEUE_DIR); git pull http://github.com/willemt/CLinkedListQueue master; popd
 
 download-contrib: clinkedlistqueue
 


### PR DESCRIPTION
Some version of git requires master to be passed on the git pull
command line when fetching CLinkedListQueue

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>