### PR TITLE
Fix test_log log object resource leaks

### DIFF
--- a/tests/test_log.c
+++ b/tests/test_log.c
@@ -89,6 +89,7 @@ void TestLog_new_is_empty(CuTest * tc)
 
     l = log_new();
     CuAssertTrue(tc, 0 == log_count(l));
+    log_free(l);
 }
 
 void TestLog_append_is_not_empty(CuTest * tc)
@@ -109,6 +110,7 @@ void TestLog_append_is_not_empty(CuTest * tc)
     log_set_callbacks(l, &funcs, r);
     CuAssertIntEquals(tc, 0, log_append_entry(l, &e));
     CuAssertIntEquals(tc, 1, log_count(l));
+    log_free(l);
 }
 
 void TestLog_get_at_idx(CuTest * tc)
@@ -131,6 +133,7 @@ void TestLog_get_at_idx(CuTest * tc)
     CuAssertIntEquals(tc, e1.id, log_get_at_idx(l, 1)->id);
     CuAssertIntEquals(tc, e2.id, log_get_at_idx(l, 2)->id);
     CuAssertIntEquals(tc, e3.id, log_get_at_idx(l, 3)->id);
+    log_free(l);
 }
 
 void TestLog_get_at_idx_returns_null_where_out_of_bounds(CuTest * tc)
@@ -147,6 +150,7 @@ void TestLog_get_at_idx_returns_null_where_out_of_bounds(CuTest * tc)
     e1.id = 1;
     CuAssertIntEquals(tc, 0, log_append_entry(l, &e1));
     CuAssertTrue(tc, NULL == log_get_at_idx(l, 2));
+    log_free(l);
 }
 
 void TestLog_delete(CuTest * tc)
@@ -191,6 +195,7 @@ void TestLog_delete(CuTest * tc)
     log_delete(l, 1);
     CuAssertIntEquals(tc, 0, log_count(l));
     CuAssertTrue(tc, NULL == log_get_at_idx(l, 1));
+    log_free(l);
 }
 
 void TestLog_delete_onwards(CuTest * tc)
@@ -226,6 +231,7 @@ void TestLog_delete_onwards(CuTest * tc)
     CuAssertIntEquals(tc, e1.id, log_get_at_idx(l, 1)->id);
     CuAssertTrue(tc, NULL == log_get_at_idx(l, 2));
     CuAssertTrue(tc, NULL == log_get_at_idx(l, 3));
+    log_free(l);
 }
 
 void TestLog_delete_handles_log_pop_failure(CuTest * tc)
@@ -261,6 +267,7 @@ void TestLog_delete_handles_log_pop_failure(CuTest * tc)
     CuAssertIntEquals(tc, 3, log_count(l));
     CuAssertIntEquals(tc, 3, log_count(l));
     CuAssertIntEquals(tc, e3.id, ((raft_entry_t*)log_peektail(l))->id);
+    log_free(l);
  }
 
 void TestLog_delete_fails_for_idx_zero(CuTest * tc)
@@ -293,6 +300,7 @@ void TestLog_delete_fails_for_idx_zero(CuTest * tc)
     CuAssertIntEquals(tc, 0, log_append_entry(l, &e3));
     CuAssertIntEquals(tc, 0, log_append_entry(l, &e4));
     CuAssertIntEquals(tc, log_delete(l, 0), -1);
+    log_free(l);
 }
 
 void TestLog_poll(CuTest * tc)
@@ -350,6 +358,7 @@ void TestLog_poll(CuTest * tc)
     CuAssertTrue(tc, NULL == log_get_at_idx(l, 2));
     CuAssertTrue(tc, NULL == log_get_at_idx(l, 3));
     CuAssertIntEquals(tc, 3, log_get_current_idx(l));
+    log_free(l);
 }
 
 void TestLog_peektail(CuTest * tc)
@@ -370,6 +379,7 @@ void TestLog_peektail(CuTest * tc)
     CuAssertIntEquals(tc, 0, log_append_entry(l, &e3));
     CuAssertIntEquals(tc, 3, log_count(l));
     CuAssertIntEquals(tc, e3.id, log_peektail(l)->id);
+    log_free(l);
 }
 
 #if 0
@@ -384,6 +394,7 @@ void T_estlog_cant_append_duplicates(CuTest * tc)
     l = log_new();
     CuAssertTrue(tc, 1 == log_append_entry(l, &e));
     CuAssertTrue(tc, 1 == log_count(l));
+    log_free(l);
 }
 #endif
 
@@ -401,6 +412,7 @@ void TestLog_load_from_snapshot(CuTest * tc)
     log_load_from_snapshot(l, 10, 5);
     CuAssertIntEquals(tc, 10, log_get_current_idx(l));
     CuAssertIntEquals(tc, 0, log_count(l));
+    log_free(l);
 }
 
 void TestLog_load_from_snapshot_clears_log(CuTest * tc)
@@ -422,6 +434,7 @@ void TestLog_load_from_snapshot_clears_log(CuTest * tc)
     log_load_from_snapshot(l, 10, 5);
     CuAssertIntEquals(tc, 0, log_count(l));
     CuAssertIntEquals(tc, 10, log_get_current_idx(l));
+    log_free(l);
 }
 
 void TestLog_front_pushes_across_boundary(CuTest * tc)
@@ -451,6 +464,7 @@ void TestLog_front_pushes_across_boundary(CuTest * tc)
     CuAssertIntEquals(tc, 0, log_poll(l, 2));
     CuAssertIntEquals(tc, 0, log_count(l));
     CuAssertIntEquals(tc, 2, log_get_base(l));
+    log_free(l);
 }
 
 void TestLog_front_and_back_pushed_across_boundary_with_enlargement_required(CuTest * tc)
@@ -494,6 +508,7 @@ void TestLog_front_and_back_pushed_across_boundary_with_enlargement_required(CuT
     CuAssertIntEquals(tc, 0, log_poll(l, 3));
     CuAssertIntEquals(tc, 1, log_count(l));
     CuAssertIntEquals(tc, 3, log_get_base(l));
+    log_free(l);
 }
 
 void TestLog_delete_after_polling(CuTest * tc)
@@ -529,6 +544,7 @@ void TestLog_delete_after_polling(CuTest * tc)
     /* delete */
     CuAssertIntEquals(tc, 0, log_delete(l, 2));
     CuAssertIntEquals(tc, 0, log_count(l));
+    log_free(l);
 }
 
 void TestLog_delete_after_polling_from_double_append(CuTest * tc)
@@ -573,6 +589,7 @@ void TestLog_delete_after_polling_from_double_append(CuTest * tc)
     /* delete */
     CuAssertIntEquals(tc, 0, log_delete(l, 2));
     CuAssertIntEquals(tc, 0, log_count(l));
+    log_free(l);
 }
 
 void TestLog_get_from_idx_with_base_off_by_one(CuTest * tc)
@@ -618,4 +635,5 @@ void TestLog_get_from_idx_with_base_off_by_one(CuTest * tc)
     CuAssertPtrNotNull(tc, ety);
     CuAssertIntEquals(tc, n_etys, 1);
     CuAssertIntEquals(tc, ety->id, 2);
+    log_free(l);
 }


### PR DESCRIPTION
Fixing some entirely unimportant log object resource leaks in test_log.c since they are technically still leaks and they show up in DAOS's coverity static analysis

Signed-off-by: Byron Marohn <byron.marohn@intel.com>