### PR TITLE
DAOS-4328 raft: fix missing va_end() identified by Coverity

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -41,6 +41,8 @@ static void __log(raft_server_t *me_, raft_node_t* node, const char *fmt, ...)
     vsprintf(buf, fmt, args);
 
     me->cb.log(me_, node, me->udata, buf);
+
+    va_end(args);
 }
 
 void raft_randomize_election_timeout(raft_server_t* me_)


### PR DESCRIPTION
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>