### PR TITLE
DAOS-1742 raft: expose raft_election_start() function

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -886,6 +886,8 @@ void raft_become_leader(raft_server_t* me);
  * currentTerm. */
 void raft_become_follower(raft_server_t* me);
 
+int raft_election_start(raft_server_t* me);
+
 /** Determine if entry is voting configuration change.
  * @param[in] ety The entry to query.
  * @return 1 if this is a voting configuration change. */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -77,8 +77,6 @@ typedef struct {
     int snapshot_last_term;
 } raft_server_private_t;
 
-int raft_election_start(raft_server_t* me);
-
 int raft_become_candidate(raft_server_t* me);
 
 void raft_randomize_election_timeout(raft_server_t* me_);

--- a/packaging/Makefile_distro_vars.mk
+++ b/packaging/Makefile_distro_vars.mk
@@ -14,7 +14,6 @@ DISTRO_BASE = $(basename UBUNTU_$(VERSION_ID))
 VERSION_ID_STR := $(subst $(DOT),_,$(VERSION_ID))
 endif
 ifeq ($(ID),fedora)
-SPECTOOL    := spectool
 # a Fedora-based mock builder
 # derive the the values of:
 # VERSION_ID (i.e. 7)
@@ -26,13 +25,6 @@ DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
 VERSION_ID  := 7
 DISTRO_ID   := el7
 DISTRO_BASE := EL_7
-SED_EXPR    := 1s/$(DIST)//p
-endif
-ifeq ($(CHROOT_NAME),epel-8-x86_64)
-DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
-VERSION_ID  := 8
-DISTRO_ID   := el8
-DISTRO_BASE := EL_8
 SED_EXPR    := 1s/$(DIST)//p
 endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.1-x86_64)
@@ -53,7 +45,6 @@ DISTRO_ID := el$(VERSION_ID)
 DISTRO_BASE := $(basename EL_$(VERSION_ID))
 DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
 SED_EXPR    := 1s/$(DIST)//p
-SPECTOOL    := spectool
 define install_repo
 	if yum-config-manager --add-repo=$(1); then                  \
 	    repo_file=$$(ls -tar /etc/yum.repos.d/*.repo | tail -1); \
@@ -75,8 +66,22 @@ DISTRO_ID := sle$(VERSION_ID)
 DISTRO_BASE := $(basename SLES_$(VERSION_ID))
 endif
 ifeq ($(ID_LIKE),suse)
-SPECTOOL    := rpmdev-spectool
 define install_repo
 	zypper --non-interactive ar $(1)
 endef
+endif
+ifeq ($(ID_LIKE),debian)
+ifndef LANG
+export LANG = C.UTF-8
+endif
+ifndef LC_ALL
+export LC_ALL = C.UTF-8
+endif
+else
+ifndef LANG
+export LANG = C.utf8
+endif
+ifndef LC_ALL
+export LC_ALL = C.utf8
+endif
 endif

--- a/raft.spec
+++ b/raft.spec
@@ -8,7 +8,7 @@
 
 Name:		raft
 Version:	0.5.0
-Release:	4%{?relval}%{?dist}
+Release:	5%{?relval}%{?dist}
 
 Summary:	C implementation of the Raft Consensus protocol, BSD licensed
 
@@ -57,6 +57,9 @@ cp -a include/* %{buildroot}/%{_includedir}
 
 
 %changelog
+* Fri May 15 2020 Kenneth Cain <kenneth.c.cainl@intel> -0.5.0-5
+- Expose raft_election_start function
+
 * Fri Apr 10 2020 Brian J. Murrell <brian.murrell@intel> -0.5.0-4
 - Add GCOV_CCFLAGS= to static build
 

--- a/raft.spec
+++ b/raft.spec
@@ -7,8 +7,8 @@
 %bcond_with use_release
 
 Name:		raft
-Version:	0.5.0
-Release:	5%{?relval}%{?dist}
+Version:	0.6.0
+Release:	1%{?relval}%{?dist}
 
 Summary:	C implementation of the Raft Consensus protocol, BSD licensed
 
@@ -57,7 +57,7 @@ cp -a include/* %{buildroot}/%{_includedir}
 
 
 %changelog
-* Fri May 15 2020 Kenneth Cain <kenneth.c.cainl@intel> -0.5.0-5
+* Fri May 15 2020 Kenneth Cain <kenneth.c.cainl@intel> -0.6.0-1
 - Expose raft_election_start function
 
 * Fri Apr 10 2020 Brian J. Murrell <brian.murrell@intel> -0.5.0-4


### PR DESCRIPTION
Move raft_election_start() function signature from private to public
header file. For DAOS use particularly in rdb/raft testing.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>