### PR TITLE
DAOS-2423 log: Use 63-bit indices and terms

### DIFF
--- a/Makefile-rpm.mk
+++ b/Makefile-rpm.mk
@@ -7,7 +7,7 @@ GIT_NUM_COMMITS := $(shell git rev-list HEAD --count)
 
 GIT_INFO := $(GIT_NUM_COMMITS).g$(GIT_SHORT)
 
-BUILD_DEFINES := --define "%relval $(GIT_INFO)"
+BUILD_DEFINES := --define "relval $(GIT_INFO)"
 RPM_BUILD_OPTIONS := $(BUILD_DEFINES)
 
 include packaging/Makefile_packaging.mk

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+raft (0.7.0-1) unstable; urgency=medium
+
+  [ Li Wei ]
+  * Use 63-bit log indices and terms
+
+-- Li Wei <wei.g.li@intel.com>  Tue, Nov 10 2020 10:12:37 +0800
+
 raft (0.6.0-1) unstable; urgency=medium
 
   [ Brian J. Murrell ]

--- a/include/raft.h
+++ b/include/raft.h
@@ -10,14 +10,18 @@
 #ifndef RAFT_H_
 #define RAFT_H_
 
-#define RAFT_ERR_NOT_LEADER                  -2
-#define RAFT_ERR_ONE_VOTING_CHANGE_ONLY      -3
-#define RAFT_ERR_SHUTDOWN                    -4
-#define RAFT_ERR_NOMEM                       -5
-#define RAFT_ERR_NEEDS_SNAPSHOT              -6
-#define RAFT_ERR_SNAPSHOT_IN_PROGRESS        -7
-#define RAFT_ERR_SNAPSHOT_ALREADY_LOADED     -8
-#define RAFT_ERR_LAST                        -100
+#include "raft_types.h"
+
+typedef enum {
+    RAFT_ERR_NOT_LEADER=-2,
+    RAFT_ERR_ONE_VOTING_CHANGE_ONLY=-3,
+    RAFT_ERR_SHUTDOWN=-4,
+    RAFT_ERR_NOMEM=-5,
+    RAFT_ERR_NEEDS_SNAPSHOT=-6,
+    RAFT_ERR_SNAPSHOT_IN_PROGRESS=-7,
+    RAFT_ERR_SNAPSHOT_ALREADY_LOADED=-8,
+    RAFT_ERR_LAST=-100,
+} raft_error_e;
 
 typedef enum {
     RAFT_MEMBERSHIP_ADD,
@@ -85,10 +89,10 @@ typedef struct
 typedef struct
 {
     /** the entry's term at the point it was created */
-    unsigned int term;
+    raft_term_t term;
 
     /** the entry's unique ID */
-    unsigned int id;
+    raft_entry_id_t id;
 
     /** type of entry */
     int type;
@@ -106,13 +110,13 @@ typedef raft_entry_t msg_entry_t;
 typedef struct
 {
     /** the entry's unique ID */
-    unsigned int id;
+    raft_entry_id_t id;
 
     /** the entry's term */
-    int term;
+    raft_term_t term;
 
     /** the entry's index */
-    int idx;
+    raft_index_t idx;
 } msg_entry_response_t;
 
 /** Vote request message.
@@ -121,16 +125,16 @@ typedef struct
 typedef struct
 {
     /** currentTerm, to force other leader/candidate to step down */
-    int term;
+    raft_term_t term;
 
     /** candidate requesting vote */
-    int candidate_id;
+    raft_node_id_t candidate_id;
 
     /** index of candidate's last log entry */
-    int last_log_idx;
+    raft_index_t last_log_idx;
 
     /** term of candidate's last log entry */
-    int last_log_term;
+    raft_term_t last_log_term;
 } msg_requestvote_t;
 
 /** Vote request response message.
@@ -138,7 +142,7 @@ typedef struct
 typedef struct
 {
     /** currentTerm, for candidate to update itself */
-    int term;
+    raft_term_t term;
 
     /** true means candidate received vote */
     int vote_granted;
@@ -151,19 +155,19 @@ typedef struct
 typedef struct
 {
     /** currentTerm, to force other leader/candidate to step down */
-    int term;
+    raft_term_t term;
 
     /** the index of the log just before the newest entry for the node who
      * receives this message */
-    int prev_log_idx;
+    raft_index_t prev_log_idx;
 
     /** the term of the log just before the newest entry for the node who
      * receives this message */
-    int prev_log_term;
+    raft_term_t prev_log_term;
 
     /** the index of the entry that has been appended to the majority of the
      * cluster. Entries up to this index will be applied to the FSM */
-    int leader_commit;
+    raft_index_t leader_commit;
 
     /** number of entries within this message */
     int n_entries;
@@ -178,7 +182,7 @@ typedef struct
 typedef struct
 {
     /** currentTerm, to force other leader/candidate to step down */
-    int term;
+    raft_term_t term;
 
     /** true if follower contained entry matching prevLogidx and prevLogTerm */
     int success;
@@ -189,33 +193,33 @@ typedef struct
 
     /** If success, this is the highest log IDX we've received and appended to
      * our log; otherwise, this is the our currentIndex */
-    int current_idx;
+    raft_index_t current_idx;
 
     /** The first idx that we received within the appendentries message */
-    int first_idx;
+    raft_index_t first_idx;
 } msg_appendentries_response_t;
 
 /** InstallSnapshot request message. */
 typedef struct
 {
     /** currentTerm, to force other leader/candidate to step down */
-    int term;
+    raft_term_t term;
 
     /** Index of the last entry represented by this snapshot */
-    int last_idx;
+    raft_index_t last_idx;
 
     /** Term of the last entry represented by this snapshot */
-    int last_term;
+    raft_term_t last_term;
 } msg_installsnapshot_t;
 
 /** InstallSnapshot response message. */
 typedef struct
 {
     /** currentTerm, to force other leader/candidate to step down */
-    int term;
+    raft_term_t term;
 
     /** Same with the one in the request message */
-    int last_idx;
+    raft_index_t last_idx;
 
     /** True if the snapshot has been fully received */
     int complete;
@@ -351,7 +355,7 @@ typedef int (
 )   (
     raft_server_t* raft,
     void *user_data,
-    int vote
+    raft_node_id_t vote
     );
 
 /** Callback for saving current term (and nil vote) to disk.
@@ -367,8 +371,8 @@ typedef int (
 )   (
     raft_server_t* raft,
     void *user_data,
-    int term,
-    int vote
+    raft_term_t term,
+    raft_node_id_t vote
     );
 
 /** Callback for saving changes to a range of log entries.
@@ -398,7 +402,7 @@ typedef int (
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entries,
-    int entry_idx,
+    raft_index_t entry_idx,
     int *n_entries
     );
 
@@ -410,7 +414,7 @@ typedef int (
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entry,
-    int entry_idx
+    raft_index_t entry_idx
     );
 
 /** Callback for being notified of membership changes.
@@ -548,7 +552,7 @@ void raft_set_callbacks(raft_server_t* me, raft_cbs_t* funcs, void* user_data);
  * @return
  *  node if it was successfully added;
  *  NULL if the node already exists */
-raft_node_t* raft_add_node(raft_server_t* me, void* user_data, int id, int is_self);
+raft_node_t* raft_add_node(raft_server_t* me, void* user_data, raft_node_id_t id, int is_self);
 
 #define raft_add_peer raft_add_node
 
@@ -558,7 +562,7 @@ raft_node_t* raft_add_node(raft_server_t* me, void* user_data, int id, int is_se
  * @return
  *  node if it was successfully added;
  *  NULL if the node already exists */
-raft_node_t* raft_add_non_voting_node(raft_server_t* me_, void* udata, int id, int is_self);
+raft_node_t* raft_add_non_voting_node(raft_server_t* me_, void* udata, raft_node_id_t id, int is_self);
 
 /** Remove node.
  * @param node The node to be removed. */
@@ -685,7 +689,7 @@ int raft_recv_entry(raft_server_t* me,
 
 /**
  * @return server's node ID; -1 if it doesn't know what it is */
-int raft_get_nodeid(raft_server_t* me);
+raft_node_id_t raft_get_nodeid(raft_server_t* me);
 
 /**
  * @return the server's node */
@@ -705,19 +709,19 @@ int raft_get_num_voting_nodes(raft_server_t* me_);
 
 /**
  * @return number of items within log */
-int raft_get_log_count(raft_server_t* me);
+raft_index_t raft_get_log_count(raft_server_t* me);
 
 /**
  * @return current term */
-int raft_get_current_term(raft_server_t* me);
+raft_term_t raft_get_current_term(raft_server_t* me);
 
 /**
  * @return current log index */
-int raft_get_current_idx(raft_server_t* me);
+raft_index_t raft_get_current_idx(raft_server_t* me);
 
 /**
  * @return commit index */
-int raft_get_commit_idx(raft_server_t* me_);
+raft_index_t raft_get_commit_idx(raft_server_t* me_);
 
 /**
  * @return 1 if follower; 0 otherwise */
@@ -741,19 +745,19 @@ int raft_get_request_timeout(raft_server_t* me);
 
 /**
  * @return index of last applied entry */
-int raft_get_last_applied_idx(raft_server_t* me);
+raft_index_t raft_get_last_applied_idx(raft_server_t* me);
 
 /**
  * Set index of the last applied entry */
-void raft_set_last_applied_idx(raft_server_t* me_, int idx);
+void raft_set_last_applied_idx(raft_server_t* me_, raft_index_t idx);
 
 /**
  * @return the node's next index */
-int raft_node_get_next_idx(raft_node_t* node);
+raft_index_t raft_node_get_next_idx(raft_node_t* node);
 
 /**
  * @return this node's user data */
-int raft_node_get_match_idx(raft_node_t* me);
+raft_index_t raft_node_get_match_idx(raft_node_t* me);
 
 /**
  * @return this node's user data */
@@ -766,18 +770,18 @@ void raft_node_set_udata(raft_node_t* me, void* user_data);
 /**
  * @param[in] idx The entry's index
  * @return entry from index */
-raft_entry_t* raft_get_entry_from_idx(raft_server_t* me, int idx);
+raft_entry_t* raft_get_entry_from_idx(raft_server_t* me, raft_index_t idx);
 
 /**
  * @param[in] node The node's ID
  * @return node pointed to by node ID */
-raft_node_t* raft_get_node(raft_server_t* me_, const int id);
+raft_node_t* raft_get_node(raft_server_t* me_, const raft_node_id_t id);
 
 /**
  * Used for iterating through nodes
  * @param[in] node The node's idx
  * @return node pointed to by node idx */
-raft_node_t* raft_get_node_from_idx(raft_server_t* me_, const int idx);
+raft_node_t* raft_get_node_from_idx(raft_server_t* me_, const raft_index_t idx);
 
 /**
  * @return number of votes this server has received this election */
@@ -785,12 +789,12 @@ int raft_get_nvotes_for_me(raft_server_t* me);
 
 /**
  * @return node ID of who I voted for */
-int raft_get_voted_for(raft_server_t* me);
+raft_node_id_t raft_get_voted_for(raft_server_t* me);
 
 /** Get what this node thinks the node ID of the leader is.
  * @return node of what this node thinks is the valid leader;
  *   -1 if the leader is unknown */
-int raft_get_current_leader(raft_server_t* me);
+raft_node_id_t raft_get_current_leader(raft_server_t* me);
 
 /** Get what this node thinks the node of the leader is.
  * @return node of what this node thinks is the valid leader;
@@ -813,19 +817,19 @@ int raft_vote(raft_server_t* me_, raft_node_t* node);
  * @param[in] nodeid The server to vote for by nodeid
  * @return
  *  0 on success */
-int raft_vote_for_nodeid(raft_server_t* me_, const int nodeid);
+int raft_vote_for_nodeid(raft_server_t* me_, const raft_node_id_t nodeid);
 
 /** Set the current term.
  * This should be used to reload persistent state, ie. the current_term field.
  * @param[in] term The new current term
  * @return
  *  0 on success */
-int raft_set_current_term(raft_server_t* me, const int term);
+int raft_set_current_term(raft_server_t* me, const raft_term_t term);
 
 /** Set the commit idx.
  * This should be used to reload persistent state, ie. the commit_idx field.
  * @param[in] commit_idx The new commit index. */
-void raft_set_commit_idx(raft_server_t* me, int commit_idx);
+void raft_set_commit_idx(raft_server_t* me, raft_index_t commit_idx);
 
 /** Add entries to the server's log.
  * This should be used to reload persistent state, ie. the commit log.
@@ -848,7 +852,7 @@ int raft_msg_entry_response_committed(raft_server_t* me_,
 
 /** Get node's ID.
  * @return ID of node */
-int raft_node_get_id(raft_node_t* me_);
+raft_node_id_t raft_node_get_id(raft_node_t* me_);
 
 /** Tell if we are a leader, candidate or follower.
  * @return get state of type raft_state_e. */
@@ -856,7 +860,7 @@ int raft_get_state(raft_server_t* me_);
 
 /** The the most recent log's term
  * @return the last log term */
-int raft_get_last_log_term(raft_server_t* me_);
+raft_term_t raft_get_last_log_term(raft_server_t* me_);
 
 /** Turn a node into a voting node.
  * Voting nodes can take part in elections and in-regards to commiting entries,
@@ -907,7 +911,7 @@ int raft_entry_is_cfg_change(raft_entry_t* ety);
  * @return 0 on success
  *
  **/
-int raft_begin_snapshot(raft_server_t *me_, int idx);
+int raft_begin_snapshot(raft_server_t *me_, raft_index_t idx);
 
 /** Stop snapshotting.
  *
@@ -927,7 +931,7 @@ int raft_end_snapshot(raft_server_t *me_);
 
 /** Get the entry index of the entry that was snapshotted
  **/
-int raft_get_snapshot_entry_idx(raft_server_t *me_);
+raft_index_t raft_get_snapshot_entry_idx(raft_server_t *me_);
 
 /** Check is a snapshot is in progress
  **/
@@ -937,7 +941,7 @@ int raft_snapshot_is_in_progress(raft_server_t *me_);
  **/
 raft_entry_t *raft_get_last_applied_entry(raft_server_t *me_);
 
-int raft_get_first_entry_idx(raft_server_t* me_);
+raft_index_t raft_get_first_entry_idx(raft_server_t* me_);
 
 /** Start loading snapshot
  *
@@ -953,8 +957,8 @@ int raft_get_first_entry_idx(raft_server_t* me_);
  *  RAFT_ERR_SNAPSHOT_ALREADY_LOADED
  **/
 int raft_begin_load_snapshot(raft_server_t *me_,
-                       int last_included_term,
-		       int last_included_index);
+                             raft_term_t last_included_term,
+		                     raft_index_t last_included_index);
 
 /** Stop loading snapshot.
  *
@@ -964,11 +968,11 @@ int raft_begin_load_snapshot(raft_server_t *me_,
  **/
 int raft_end_load_snapshot(raft_server_t *me_);
 
-int raft_get_snapshot_last_idx(raft_server_t *me_);
+raft_index_t raft_get_snapshot_last_idx(raft_server_t *me_);
 
-int raft_get_snapshot_last_term(raft_server_t *me_);
+raft_term_t raft_get_snapshot_last_term(raft_server_t *me_);
 
-void raft_set_snapshot_metadata(raft_server_t *me_, int term, int idx);
+void raft_set_snapshot_metadata(raft_server_t *me_, raft_term_t term, raft_index_t idx);
 
 /** Check if a node is active.
  * Active nodes could become voting nodes.

--- a/include/raft_log.h
+++ b/include/raft_log.h
@@ -1,11 +1,13 @@
 #ifndef RAFT_LOG_H_
 #define RAFT_LOG_H_
 
+#include "raft_types.h"
+
 typedef void* log_t;
 
-log_t* log_new();
+log_t* log_new(void);
 
-log_t* log_alloc(int initial_size);
+log_t* log_alloc(raft_index_t initial_size);
 
 void log_set_callbacks(log_t* me_, raft_cbs_t* funcs, void* raft);
 
@@ -21,11 +23,11 @@ int log_append(log_t* me_, raft_entry_t* entries, int *n);
 
 /**
  * @return number of entries held within log */
-int log_count(log_t* me_);
+raft_index_t log_count(log_t* me_);
 
 /**
  * Delete all logs from this log onwards */
-int log_delete(log_t* me_, int idx);
+int log_delete(log_t* me_, raft_index_t idx);
 
 /**
  * Empty the queue. */
@@ -33,25 +35,25 @@ void log_empty(log_t * me_);
 
 /**
  * Remove all entries before and at idx. */
-int log_poll(log_t * me_, int idx);
+int log_poll(log_t * me_, raft_index_t idx);
 
 /** Get an array of entries from this index onwards.
  * This is used for batching.
  */
-raft_entry_t* log_get_from_idx(log_t* me_, int idx, int *n_etys);
+raft_entry_t* log_get_from_idx(log_t* me_, raft_index_t idx, int *n_etys);
 
-raft_entry_t* log_get_at_idx(log_t* me_, int idx);
+raft_entry_t* log_get_at_idx(log_t* me_, raft_index_t idx);
 
 /**
  * @return youngest entry */
 raft_entry_t *log_peektail(log_t * me_);
 
-int log_get_current_idx(log_t* me_);
+raft_index_t log_get_current_idx(log_t* me_);
 
-void log_load_from_snapshot(log_t *me_, int idx, int term);
+void log_load_from_snapshot(log_t *me_, raft_index_t idx, raft_term_t term);
 
-int log_get_base(log_t* me_);
+raft_index_t log_get_base(log_t* me_);
 
-int log_get_base_term(log_t* me_);
+raft_term_t log_get_base_term(log_t* me_);
 
 #endif /* RAFT_LOG_H_ */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -10,6 +10,8 @@
 #ifndef RAFT_PRIVATE_H_
 #define RAFT_PRIVATE_H_
 
+#include "raft_types.h"
+
 enum {
     RAFT_NODE_STATUS_DISCONNECTED,
     RAFT_NODE_STATUS_CONNECTED,
@@ -22,11 +24,11 @@ typedef struct {
 
     /* the server's best guess of what the current term is
      * starts at zero */
-    int current_term;
+    raft_term_t current_term;
 
     /* The candidate the server voted for in its current term,
      * or Nil if it hasn't voted for any.  */
-    int voted_for;
+    raft_node_id_t voted_for;
 
     /* the log which is replicated */
     void* log;
@@ -34,10 +36,10 @@ typedef struct {
     /* Volatile state: */
 
     /* idx of highest log entry known to be committed */
-    int commit_idx;
+    raft_index_t commit_idx;
 
     /* idx of highest log entry applied to state machine */
-    int last_applied_idx;
+    raft_index_t last_applied_idx;
 
     /* follower/leader/candidate indicator */
     int state;
@@ -54,17 +56,17 @@ typedef struct {
 
     /* what this node thinks is the node ID of the current leader,
      * or -1 if there isn't a known current leader. */
-    int leader_id;
+    raft_node_id_t leader_id;
 
     /* my node ID */
-    int node_id;
+    raft_node_id_t node_id;
 
     /* callbacks */
     raft_cbs_t cb;
     void* udata;
 
     /* the log which has a voting cfg change, otherwise -1 */
-    int voting_cfg_change_log_idx;
+    raft_index_t voting_cfg_change_log_idx;
 
     /* Our membership with the cluster is confirmed (ie. configuration log was
      * committed) */
@@ -73,8 +75,8 @@ typedef struct {
     int snapshot_in_progress;
 
     /* Last compacted snapshot */
-    int snapshot_last_idx;
-    int snapshot_last_term;
+    raft_index_t snapshot_last_idx;
+    raft_term_t snapshot_last_term;
 } raft_server_private_t;
 
 int raft_become_candidate(raft_server_t* me);
@@ -100,7 +102,7 @@ int raft_apply_entry(raft_server_t* me_);
  * @return 0 if unsuccessful */
 int raft_append_entries(raft_server_t* me, raft_entry_t* entries, int *n);
 
-void raft_set_last_applied_idx(raft_server_t* me, int idx);
+void raft_set_last_applied_idx(raft_server_t* me, raft_index_t idx);
 
 void raft_set_state(raft_server_t* me_, int state);
 
@@ -110,25 +112,25 @@ int raft_get_state(raft_server_t* me_);
  * @return 1 if node ID matches the server; 0 otherwise */
 int raft_is_self(raft_server_t* me_, raft_node_t* node);
 
-raft_node_t* raft_node_new(void* udata, int id);
+raft_node_t* raft_node_new(void* udata, raft_node_id_t id);
 
 void raft_node_free(raft_node_t* me_);
 
 void raft_node_set_server(raft_node_t* me_, raft_server_t *server);
 
-void raft_node_set_next_idx(raft_node_t* node, int nextIdx);
+void raft_node_set_next_idx(raft_node_t* node, raft_index_t nextIdx);
 
-void raft_node_set_match_idx(raft_node_t* node, int matchIdx);
+void raft_node_set_match_idx(raft_node_t* node, raft_index_t matchIdx);
 
-int raft_node_get_match_idx(raft_node_t* me_);
+raft_index_t raft_node_get_match_idx(raft_node_t* me_);
 
-void raft_node_set_offered_idx(raft_node_t* me_, int offeredIdx);
+void raft_node_set_offered_idx(raft_node_t* me_, raft_index_t offeredIdx);
 
-int raft_node_get_offered_idx(raft_node_t* me_);
+raft_index_t raft_node_get_offered_idx(raft_node_t* me_);
 
-void raft_node_set_applied_idx(raft_node_t* me_, int appliedIdx);
+void raft_node_set_applied_idx(raft_node_t* me_, raft_index_t appliedIdx);
 
-int raft_node_get_applied_idx(raft_node_t* me_);
+raft_index_t raft_node_get_applied_idx(raft_node_t* me_);
 
 void raft_node_vote_for_me(raft_node_t* me_, const int vote);
 
@@ -139,12 +141,12 @@ void raft_node_set_has_sufficient_logs(raft_node_t* me_);
 int raft_votes_is_majority(const int nnodes, const int nvotes);
 
 void raft_offer_log(raft_server_t* me_, raft_entry_t* entries,
-                    int n_entries, int idx);
+                    int n_entries, raft_index_t idx);
 
 void raft_pop_log(raft_server_t* me_, raft_entry_t* entries,
-                  int n_entries, int idx);
+                  int n_entries, raft_index_t idx);
 
-int raft_get_num_snapshottable_logs(raft_server_t* me_);
+raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me_);
 
 int raft_node_is_active(raft_node_t* me_);
 
@@ -152,6 +154,6 @@ void raft_node_set_voting_committed(raft_node_t* me_, int voting);
 
 int raft_node_set_addition_committed(raft_node_t* me_, int committed);
 
-int raft_get_entry_term(raft_server_t* me_, int idx, int* term);
+int raft_get_entry_term(raft_server_t* me_, raft_index_t idx, raft_term_t* term);
 
 #endif /* RAFT_PRIVATE_H_ */

--- a/include/raft_types.h
+++ b/include/raft_types.h
@@ -1,0 +1,30 @@
+
+#ifndef RAFT_DEFS_H_
+#define RAFT_DEFS_H_
+
+#include <stdint.h>
+
+/**
+ * Unique entry ids are mostly used for debugging and nothing else,
+ * so there is little harm if they collide.
+ */
+typedef int raft_entry_id_t;
+
+/**
+ * Monotonic term counter.
+ */
+typedef long int raft_term_t;
+
+/**
+ * Monotonic log entry index.
+ *
+ * This is also used to as an entry count size type.
+ */
+typedef long int raft_index_t;
+
+/**
+ * Unique node identifier.
+ */
+typedef int raft_node_id_t;
+
+#endif  /* RAFT_DEFS_H_ */

--- a/raft.spec
+++ b/raft.spec
@@ -7,7 +7,7 @@
 %bcond_with use_release
 
 Name:		raft
-Version:	0.6.0
+Version:	0.7.0
 Release:	1%{?relval}%{?dist}
 
 Summary:	C implementation of the Raft Consensus protocol, BSD licensed
@@ -57,6 +57,9 @@ cp -a include/* %{buildroot}/%{_includedir}
 
 
 %changelog
+* Tue Nov 10 2020 Li Wei <wei.g.li@intel.com> -0.7.0-1
+- Use 63-bit log indices and terms
+
 * Fri May 15 2020 Kenneth Cain <kenneth.c.cainl@intel> -0.6.0-1
 - Expose raft_election_start function
 

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -24,19 +24,19 @@ typedef struct
     raft_server_t* server;
     void* udata;
 
-    int next_idx;
-    int match_idx;
+    raft_index_t next_idx;
+    raft_index_t match_idx;
     /* index of last offered log entry for this node */
-    int offered_idx;
+    raft_index_t offered_idx;
     /* index of last committed log entry for this node */
-    int applied_idx;
+    raft_index_t applied_idx;
 
     int flags;
 
-    int id;
+    raft_node_id_t id;
 } raft_node_private_t;
 
-raft_node_t* raft_node_new(void* udata, int id)
+raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
 {
     raft_node_private_t* me;
     me = (raft_node_private_t*)calloc(1, sizeof(raft_node_private_t));
@@ -63,50 +63,50 @@ void raft_node_set_server(raft_node_t* me_, raft_server_t *server)
     me->server = server;
 }
 
-int raft_node_get_next_idx(raft_node_t* me_)
+raft_index_t raft_node_get_next_idx(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->next_idx;
 }
 
-void raft_node_set_next_idx(raft_node_t* me_, int nextIdx)
+void raft_node_set_next_idx(raft_node_t* me_, raft_index_t nextIdx)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     /* log index begins at 1 */
     me->next_idx = nextIdx < 1 ? 1 : nextIdx;
 }
 
-int raft_node_get_match_idx(raft_node_t* me_)
+raft_index_t raft_node_get_match_idx(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->match_idx;
 }
 
-void raft_node_set_match_idx(raft_node_t* me_, int matchIdx)
+void raft_node_set_match_idx(raft_node_t* me_, raft_index_t matchIdx)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     me->match_idx = matchIdx;
 }
 
-int raft_node_get_offered_idx(raft_node_t* me_)
+raft_index_t raft_node_get_offered_idx(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->offered_idx;
 }
 
-void raft_node_set_offered_idx(raft_node_t* me_, int offeredIdx)
+void raft_node_set_offered_idx(raft_node_t* me_, raft_index_t offeredIdx)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     me->offered_idx = offeredIdx;
 }
 
-int raft_node_get_applied_idx(raft_node_t* me_)
+raft_index_t raft_node_get_applied_idx(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->applied_idx;
 }
 
-void raft_node_set_applied_idx(raft_node_t* me_, int appliedIdx)
+void raft_node_set_applied_idx(raft_node_t* me_, raft_index_t appliedIdx)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     me->applied_idx = appliedIdx;
@@ -191,7 +191,7 @@ int raft_node_is_addition_committed(raft_node_t* me_)
     return (!ety || ety->type != RAFT_LOGTYPE_REMOVE_NODE);
 }
 
-int raft_node_get_id(raft_node_t* me_)
+raft_node_id_t raft_node_get_id(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return (NULL == me) ? -1 : me->id;

--- a/tests/test_log.c
+++ b/tests/test_log.c
@@ -12,11 +12,11 @@
 #include "raft_log.h"
 #include "raft_private.h"
 
-static int __logentry_get_node_id(
+static raft_node_id_t __logentry_get_node_id(
     raft_server_t* raft,
     void *udata,
     raft_entry_t *ety,
-    int ety_idx
+    raft_index_t ety_idx
     )
 {
     return 0;
@@ -26,7 +26,7 @@ static int __log_offer(
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entries,
-    int entry_idx,
+    raft_index_t entry_idx,
     int *n_entries
     )
 {
@@ -38,7 +38,7 @@ static int __log_pop(
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entry,
-    int entry_idx,
+    raft_index_t entry_idx,
     int *n_entries
     )
 {
@@ -56,7 +56,7 @@ static int __log_pop_failing(
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entry,
-    int entry_idx,
+    raft_index_t entry_idx,
     int *n_entries
     )
 {

--- a/tests/test_scenario.c
+++ b/tests/test_scenario.c
@@ -14,8 +14,8 @@
 static int __raft_persist_term(
     raft_server_t* raft,
     void *udata,
-    int term,
-    int vote
+    raft_term_t term,
+    raft_node_id_t vote
     )
 {
     return 0;
@@ -24,7 +24,7 @@ static int __raft_persist_term(
 static int __raft_persist_vote(
     raft_server_t* raft,
     void *udata,
-    int vote
+    raft_node_id_t vote
     )
 {
     return 0;

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -17,8 +17,8 @@
 static int __raft_persist_term(
     raft_server_t* raft,
     void *udata,
-    int term,
-    int vote
+    raft_term_t term,
+    raft_node_id_t vote
     )
 {
     return 0;
@@ -27,7 +27,7 @@ static int __raft_persist_term(
 static int __raft_persist_vote(
     raft_server_t* raft,
     void *udata,
-    int vote
+    raft_node_id_t vote
     )
 {
     return 0;
@@ -37,7 +37,7 @@ int __raft_applylog(
     raft_server_t* raft,
     void *udata,
     raft_entry_t *ety,
-    int idx
+    raft_index_t idx
     )
 {
     return 0;
@@ -47,7 +47,7 @@ int __raft_applylog_shutdown(
     raft_server_t* raft,
     void *udata,
     raft_entry_t *ety,
-    int idx
+    raft_index_t idx
     )
 {
     return RAFT_ERR_SHUTDOWN;
@@ -72,7 +72,7 @@ static int __raft_send_appendentries(raft_server_t* raft,
 static int __raft_log_get_node_id(raft_server_t* raft,
         void *udata,
         raft_entry_t *entry,
-        int entry_idx)
+        raft_index_t entry_idx)
 {
     return atoi(entry->data.buf);
 }
@@ -80,7 +80,7 @@ static int __raft_log_get_node_id(raft_server_t* raft,
 static int __raft_log_offer(raft_server_t* raft,
         void* udata,
         raft_entry_t *entries,
-        int entry_idx,
+        raft_index_t entry_idx,
         int *n_entries)
 {
     int i;
@@ -351,7 +351,7 @@ static int __raft_logentry_offer(
     raft_server_t* raft,
     void *udata,
     raft_entry_t *ety,
-    int ety_idx,
+    raft_index_t ety_idx,
     int *n_entries
     )
 {
@@ -479,7 +479,7 @@ void TestRaft_server_wont_apply_entry_if_there_isnt_a_majority(CuTest* tc)
 }
 
 /* If commitidx > lastApplied: increment lastApplied, apply log[lastApplied]
- * to state machine (§5.3) */
+ * to state machine (ï¿½5.3) */
 void TestRaft_server_increment_lastApplied_when_lastApplied_lt_commitidx(
     CuTest* tc)
 {
@@ -856,7 +856,7 @@ void TestRaft_server_recv_requestvote_response_must_be_candidate_to_receive(
     CuAssertTrue(tc, 0 == raft_get_nvotes_for_me(r));
 }
 
-/* Reply false if term < currentTerm (§5.1) */
+/* Reply false if term < currentTerm (ï¿½5.1) */
 void TestRaft_server_recv_requestvote_reply_false_if_term_less_than_current_term(
     CuTest * tc
     )
@@ -914,7 +914,7 @@ void TestRaft_leader_recv_requestvote_does_not_step_down(
     CuAssertIntEquals(tc, 1, raft_get_current_leader(r));
 }
 
-/* Reply true if term >= currentTerm (§5.1) */
+/* Reply true if term >= currentTerm (ï¿½5.1) */
 void TestRaft_server_recv_requestvote_reply_true_if_term_greater_than_or_equal_to_current_term(
     CuTest * tc
     )
@@ -1038,7 +1038,7 @@ void TestRaft_server_recv_requestvote_depends_on_candidate_id(
 }
 
 /* If votedFor is null or candidateId, and candidate's log is at
- * least as up-to-date as local log, grant vote (§5.2, §5.4) */
+ * least as up-to-date as local log, grant vote (ï¿½5.2, ï¿½5.4) */
 void TestRaft_server_recv_requestvote_dont_grant_vote_if_we_didnt_vote_for_this_candidate(
     CuTest * tc
     )
@@ -1577,14 +1577,14 @@ typedef enum {
 
 typedef struct {
     __raft_error_type_e type;
-    int idx;
+    raft_index_t idx;
 } __raft_error_t;
 
 static int __raft_log_offer_error(
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entry,
-    int entry_idx,
+    raft_index_t entry_idx,
     int *n_entries)
 {
     __raft_error_t *error = user_data;
@@ -1601,7 +1601,7 @@ static int __raft_log_pop_error(
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entry,
-    int entry_idx,
+    raft_index_t entry_idx,
     int *n_entries)
 {
     __raft_error_t *error = user_data;
@@ -2623,7 +2623,7 @@ void TestRaft_leader_sends_appendentries_with_NextIdx_when_PrevIdx_gt_NextIdx(
     raft_set_state(r, RAFT_STATE_LEADER);
 
     raft_entry_t etys[3] = {};
-    int i;
+    raft_index_t i;
     for (i = 0; i < 3; i++)
     {
         etys[i].term = 1;
@@ -2659,7 +2659,7 @@ void TestRaft_leader_sends_appendentries_with_leader_commit(
     /* i'm leader */
     raft_set_state(r, RAFT_STATE_LEADER);
 
-    int i;
+    raft_index_t i;
 
     for (i=0; i<10; i++)
     {
@@ -2795,7 +2795,7 @@ void TestRaft_leader_retries_appendentries_with_decremented_NextIdx_log_inconsis
 /*
  * If there exists an N such that N > commitidx, a majority
  * of matchidx[i] = N, and log[N].term == currentTerm:
- * set commitidx = N (§5.2, §5.4).  */
+ * set commitidx = N (ï¿½5.2, ï¿½5.4).  */
 void TestRaft_leader_append_entry_to_log_increases_idxno(CuTest * tc)
 {
     raft_cbs_t funcs = {

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -14,8 +14,8 @@
 static int __raft_persist_term(
     raft_server_t* raft,
     void *udata,
-    int term,
-    int vote
+    raft_term_t term,
+    raft_node_id_t vote
     )
 {
     return 0;
@@ -24,7 +24,7 @@ static int __raft_persist_term(
 static int __raft_persist_vote(
     raft_server_t* raft,
     void *udata,
-    int vote
+    raft_node_id_t vote
     )
 {
     return 0;
@@ -34,7 +34,7 @@ static int __raft_applylog(
     raft_server_t* raft,
     void *udata,
     raft_entry_t *ety,
-    int idx
+    raft_index_t idx
     )
 {
     return 0;


### PR DESCRIPTION
Current 31-bit log indices are insufficient for production deployments.
This patch, based on upstream commit 2343e58b by Yossi Gottlieb, changes
both the log index type and the term type to long int.

Additionally, packaging changes from Brian Murrell are incorporated.

Signed-off-by: Li Wei <wei.g.li@intel.com>