### PR TITLE
DAOS-5731 misc: Fix Coverity issues

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,16 @@
+raft (0.7.1-1) unstable; urgency=medium
+
+  [ Li Wei ]
+  * Fix Coverity issues
+
+ -- Li Wei <wei.g.li@intel.com>  Wed, Dec 02 2020 11:30:00 +0800
+
 raft (0.7.0-1) unstable; urgency=medium
 
   [ Li Wei ]
   * Use 63-bit log indices and terms
 
--- Li Wei <wei.g.li@intel.com>  Tue, Nov 10 2020 10:12:37 +0800
+ -- Li Wei <wei.g.li@intel.com>  Tue, Nov 10 2020 10:12:37 +0800
 
 raft (0.6.0-1) unstable; urgency=medium
 

--- a/packaging/Makefile_packaging.mk
+++ b/packaging/Makefile_packaging.mk
@@ -378,38 +378,47 @@ test:
 	$(call install_repos,$(REPO_NAME)@$(BRANCH_NAME):$(BUILD_NUMBER))
 	yum -y install $(TEST_PACKAGES)
 
+show_spec:
+	@echo '$(SPEC)'
+
+show_build_defines:
+	@echo '$(BUILD_DEFINES)'
+
+show_common_rpm_args:
+	@echo '$(COMMON_RPM_ARGS)'
+
 show_version:
-	@echo $(VERSION)
+	@echo '$(VERSION)'
 
 show_release:
-	@echo $(RELEASE)
+	@echo '$(RELEASE)'
 
 show_rpms:
-	@echo $(RPMS)
+	@echo '$(RPMS)'
 
 show_source:
-	@echo $(SOURCE)
+	@echo '$(SOURCE)'
 
 show_patches:
-	@echo $(PATCHES)
+	@echo '$(PATCHES)'
 
 show_sources:
-	@echo $(SOURCES)
+	@echo '$(SOURCES)'
 
 show_other_sources:
-	@echo $(OTHER_SOURCES)
+	@echo '$(OTHER_SOURCES)'
 
 show_targets:
-	@echo $(TARGETS)
+	@echo '$(TARGETS)'
 
 show_makefiles:
-	@echo $(MAKEFILE_LIST)
+	@echo '$(MAKEFILE_LIST)'
 
 show_calling_makefile:
-	@echo $(CALLING_MAKEFILE)
+	@echo '$(CALLING_MAKEFILE)'
 
 show_git_metadata:
-	@echo $(GIT_SHA1):$(GIT_SHORT):$(GIT_NUM_COMMITS)
+	@echo '$(GIT_SHA1):$(GIT_SHORT):$(GIT_NUM_COMMITS)'
 
 .PHONY: srpm rpms debs deb_detar ls chrootbuild rpmlint FORCE        \
         show_version show_release show_rpms show_source show_sources \

--- a/raft.spec
+++ b/raft.spec
@@ -7,7 +7,7 @@
 %bcond_with use_release
 
 Name:		raft
-Version:	0.7.0
+Version:	0.7.1
 Release:	1%{?relval}%{?dist}
 
 Summary:	C implementation of the Raft Consensus protocol, BSD licensed
@@ -57,6 +57,9 @@ cp -a include/* %{buildroot}/%{_includedir}
 
 
 %changelog
+* Wed Dec 02 2020 Li Wei <wei.g.li@intel.com> -0.7.1-1
+- Fix Coverity issues
+
 * Tue Nov 10 2020 Li Wei <wei.g.li@intel.com> -0.7.0-1
 - Use 63-bit log indices and terms
 

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -2069,7 +2069,7 @@ void TestRaft_follower_recv_appendentries_does_not_deleted_commited_entries(
     ae.prev_log_term = 1;
     /* include entries */
     memset(&e, 0, sizeof(msg_entry_t) * 5);
-    e[0].id = 1;
+    e[0].term = 1;
     e[0].id = 5;
     e[1].term = 1;
     e[1].id = 6;


### PR DESCRIPTION
This patch fixes the following issues found by Coverity:

  - Due to my recent "63-bit indices and terms" change, print formats
    for indices and terms should be changed from "%d" to "%ld".
  - What appears to be a copy-paste error in test_server.c.

Signed-off-by: Li Wei <wei.g.li@intel.com>