### PR TITLE
DAOS-5044-test: Fix python bandit errors on log_fuzzer.py

### DIFF
--- a/tests/log_fuzzer.py
+++ b/tests/log_fuzzer.py
@@ -28,7 +28,7 @@ class Libraft(object):
         self.lib = ffi.dlopen(library)
 
         def load(fname):
-            return subprocess.check_output(["gcc", "-E", fname])
+            return subprocess.check_output(["/bin/gcc", "-E", fname])
 
         ffi.cdef(load('include/raft.h'))
         ffi.cdef(load('include/raft_log.h'))
@@ -85,7 +85,7 @@ class CoreTestCase(unittest.TestCase):
                 unique_id += 1
 
                 ret = r.log_append_entry(l, entry)
-                assert ret == 0
+                assert ret == 0 # nosec
 
                 log.append(entry)
 
@@ -94,20 +94,20 @@ class CoreTestCase(unittest.TestCase):
 
                 if log.entries:
                     ret = r.log_poll(l, entry_ptr)
-                    assert ret == 0
+                    assert ret == 0 # nosec
 
                     ety_expected = log.poll()
                     ety_actual = self.r.ffi.cast('raft_entry_t**', entry_ptr)[0]
-                    assert ety_actual.id == ety_expected.id
+                    assert ety_actual.id == ety_expected.id # nosec
 
             elif isinstance(cmd, int):
                 if log.entries:
                     log.delete(cmd)
                     ret = r.log_delete(l, cmd)
-                    assert ret == 0
+                    assert ret == 0 # nosec
 
             else:
-                assert False
+                assert False # nosec
 
             self.assertEqual(r.log_count(l), log.count())
 

--- a/tests/log_fuzzer.py
+++ b/tests/log_fuzzer.py
@@ -5,6 +5,7 @@ import unittest
 
 from hypothesis import given
 from hypothesis.strategies import lists, just, integers, one_of
+from distutils.spawn import find_executable
 
 
 class Libraft(object):
@@ -28,7 +29,8 @@ class Libraft(object):
         self.lib = ffi.dlopen(library)
 
         def load(fname):
-            return subprocess.check_output(["/bin/gcc", "-E", fname])
+            gcc = find_executable('gcc')
+            return subprocess.check_output([gcc, "-E", fname])
 
         ffi.cdef(load('include/raft.h'))
         ffi.cdef(load('include/raft_log.h'))

--- a/tests/log_fuzzer.py
+++ b/tests/log_fuzzer.py
@@ -30,7 +30,15 @@ class Libraft(object):
 
         def load(fname):
             gcc = find_executable('gcc')
-            return subprocess.check_output([gcc, "-E", fname])
+            if gcc is None:
+                print("#Error, unable to locate gcc")
+                return 1
+            elif not gcc.startswith('/usr/bin') and not gcc.startswith('/bin'):
+                print("#Error, find_executable(gcc)=", gcc)
+                print("#Unable to locate gcc under /bin or /usr/bin.")
+                return 1
+            else:
+                return subprocess.check_output([gcc, "-E", fname])
 
         ffi.cdef(load('include/raft.h'))
         ffi.cdef(load('include/raft_log.h'))


### PR DESCRIPTION
Description: Fix the warning/errors raised by python bandit check (similar to pylint with security-check)

modified: raft/tests/log_fuzzer.py

Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>