### PR TITLE
Coverity fix test_server: raft_get_entry_from_idx return val

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+raft (0.7.2-1) unstable; urgency=medium
+
+  [ Kenneth Cain ]
+  * Fix more Coverity issues in test_server
+
+ -- Kenneth Cain <kenneth.c.cain@intel.com>  Tue, Feb 09 2021 15:20:00 +0800
+
 raft (0.7.1-1) unstable; urgency=medium
 
   [ Li Wei ]

--- a/packaging/Makefile_packaging.mk
+++ b/packaging/Makefile_packaging.mk
@@ -131,7 +131,7 @@ _topdir/SOURCES/%: % | _topdir/SOURCES/
 # At least one spec file, SLURM (sles), has a different version for the
 # download file than the version in the spec file.
 ifeq ($(DL_VERSION),)
-DL_VERSION = $(VERSION)
+DL_VERSION = $(subst ~,,$(VERSION))
 endif
 ifeq ($(DL_NAME),)
 DL_NAME = $(NAME)
@@ -389,6 +389,9 @@ show_common_rpm_args:
 
 show_version:
 	@echo '$(VERSION)'
+
+show_dl_version:
+	@echo '$(DL_VERSION)'
 
 show_release:
 	@echo '$(RELEASE)'

--- a/packaging/rpm_chrootbuild
+++ b/packaging/rpm_chrootbuild
@@ -6,6 +6,13 @@ set -uex
 IFS=\| read -r -a distro_base_local_repos <<< "$DISTRO_BASE_LOCAL_REPOS"
 
 if [ -w /etc/mock/"$CHROOT_NAME".cfg ]; then
+    # Remove the distro repos
+    if [[ $CHROOT_NAME =~ opensuse-leap-* ]]; then
+        ed /etc/mock/"$CHROOT_NAME".cfg << EOF
+/^# repos$/+2;/^"""$/-1d
+wq
+EOF
+    fi
     echo -e "config_opts['yum.conf'] += \"\"\"\n" >> /etc/mock/"$CHROOT_NAME".cfg
     for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
         branch="master"

--- a/raft.spec
+++ b/raft.spec
@@ -7,7 +7,7 @@
 %bcond_with use_release
 
 Name:		raft
-Version:	0.7.1
+Version:	0.7.2
 Release:	1%{?relval}%{?dist}
 
 Summary:	C implementation of the Raft Consensus protocol, BSD licensed
@@ -57,13 +57,16 @@ cp -a include/* %{buildroot}/%{_includedir}
 
 
 %changelog
+* Tue Feb 09 2021 Kenneth Cain <kenneth.c.cain@intel> - 0.7.2-1
+- Fix more Coverity issues in test_server
+
 * Wed Dec 02 2020 Li Wei <wei.g.li@intel.com> -0.7.1-1
 - Fix Coverity issues
 
 * Tue Nov 10 2020 Li Wei <wei.g.li@intel.com> -0.7.0-1
 - Use 63-bit log indices and terms
 
-* Fri May 15 2020 Kenneth Cain <kenneth.c.cainl@intel> -0.6.0-1
+* Fri May 15 2020 Kenneth Cain <kenneth.c.cain@intel> -0.6.0-1
 - Expose raft_election_start function
 
 * Fri Apr 10 2020 Brian J. Murrell <brian.murrell@intel> -0.5.0-4

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -329,6 +329,7 @@ void TestRaft_server_append_entry_means_entry_gets_current_term(CuTest* tc)
 
 void TestRaft_server_append_entry_is_retrievable(CuTest * tc)
 {
+  raft_entry_t* kept;
     void *r = raft_new();
     raft_set_callbacks(r, &generic_funcs, NULL);
     raft_set_state(r, RAFT_STATE_CANDIDATE);
@@ -341,7 +342,7 @@ void TestRaft_server_append_entry_is_retrievable(CuTest * tc)
     ety.data.buf = (unsigned char*)"aaa";
     raft_append_entry(r, &ety);
 
-    raft_entry_t* kept =  raft_get_entry_from_idx(r, 1);
+    CuAssertTrue(tc, NULL != (kept = raft_get_entry_from_idx(r, 1)));
     CuAssertTrue(tc, NULL != kept->data.buf);
     CuAssertIntEquals(tc, ety.data.len, kept->data.len);
     CuAssertTrue(tc, kept->data.buf == ety.data.buf);
@@ -367,6 +368,7 @@ void TestRaft_server_append_entry_user_can_set_data_buf(CuTest * tc)
         .persist_term = __raft_persist_term,
     };
     char *buf = "aaa";
+    raft_entry_t* kept;
 
     void *r = raft_new();
     raft_set_state(r, RAFT_STATE_CANDIDATE);
@@ -380,7 +382,7 @@ void TestRaft_server_append_entry_user_can_set_data_buf(CuTest * tc)
     raft_append_entry(r, &ety);
     /* User's input entry is intact. */
     CuAssertTrue(tc, ety.data.buf == buf);
-    raft_entry_t* kept =  raft_get_entry_from_idx(r, 1);
+    CuAssertTrue(tc, NULL != (kept = raft_get_entry_from_idx(r, 1)));
     CuAssertTrue(tc, NULL != kept->data.buf);
     /* Data buf is the one set by log_offer. */
     CuAssertTrue(tc, kept->data.buf == tc);
@@ -1223,7 +1225,7 @@ void TestRaft_follower_recv_appendentries_increases_log(CuTest * tc)
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
     };
-
+    raft_entry_t *log;
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
@@ -1260,7 +1262,7 @@ void TestRaft_follower_recv_appendentries_increases_log(CuTest * tc)
     raft_recv_appendentries(r, raft_get_node(r, 2), &ae, &aer);
     CuAssertTrue(tc, 1 == aer.success);
     CuAssertTrue(tc, 1 == raft_get_log_count(r));
-    raft_entry_t* log = raft_get_entry_from_idx(r, 1);
+    CuAssertTrue(tc, NULL != (log = raft_get_entry_from_idx(r, 1)));
     CuAssertTrue(tc, 2 == log->term);
 }
 


### PR DESCRIPTION
Assert the returned pointer from raft_get_entry_from_idx() is non-NULL.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>