### PR TITLE
DAOS-6833 server: Add Pre-Vote

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -119,7 +119,7 @@ typedef struct
     raft_index_t idx;
 } msg_entry_response_t;
 
-/** Vote request message.
+/** Vote/prevote request message.
  * Sent to nodes when a server wants to become leader.
  * This message could force a leader/candidate to become a follower. */
 typedef struct
@@ -135,10 +135,13 @@ typedef struct
 
     /** term of candidate's last log entry */
     raft_term_t last_log_term;
+
+    /** true if this is a prevote request */
+    int prevote;
 } msg_requestvote_t;
 
-/** Vote request response message.
- * Indicates if node has accepted the server's vote request. */
+/** Vote/prevote response message.
+ * Indicates if node has accepted, or would accept, the server's vote request. */
 typedef struct
 {
     /** currentTerm, for candidate to update itself */
@@ -146,6 +149,9 @@ typedef struct
 
     /** true means candidate received vote */
     int vote_granted;
+
+    /** true if this is a prevote response */
+    int prevote;
 } msg_requestvote_response_t;
 
 /** Appendentries message.
@@ -890,7 +896,7 @@ void raft_become_leader(raft_server_t* me);
  * currentTerm. */
 void raft_become_follower(raft_server_t* me);
 
-int raft_election_start(raft_server_t* me);
+void raft_election_start(raft_server_t* me);
 
 /** Determine if entry is voting configuration change.
  * @param[in] ety The entry to query.

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -84,6 +84,7 @@ typedef struct {
 
 void raft_become_candidate(raft_server_t* me);
 int raft_become_prevoted_candidate(raft_server_t* me_);
+int raft_is_prevoted_candidate(raft_server_t* me_);
 
 void raft_randomize_election_timeout(raft_server_t* me_);
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -44,6 +44,9 @@ typedef struct {
     /* follower/leader/candidate indicator */
     int state;
 
+    /* true if this server is in the candidate prevote state (§4.2.3, §9.6) */
+    int prevote;
+
     /* amount of time left till timeout */
     int timeout_elapsed;
  
@@ -79,7 +82,8 @@ typedef struct {
     raft_term_t snapshot_last_term;
 } raft_server_private_t;
 
-int raft_become_candidate(raft_server_t* me);
+void raft_become_candidate(raft_server_t* me);
+int raft_become_prevoted_candidate(raft_server_t* me_);
 
 void raft_randomize_election_timeout(raft_server_t* me_);
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -563,10 +563,11 @@ static int __should_grant_vote(raft_server_private_t* me, msg_requestvote_t* vr)
     if (my_node && !raft_node_is_voting(my_node))
         return 0;
 
-    /* For a prevote, we could proceed to the votedFor check, if
-     * vr->term == currentTerm - 1. That would only matter if we had
-     * rejected a previous RequestVote from a third server, who had
-     * already won a prevote phase. */
+    /* For a prevote, we could theoretically proceed to the votedFor check
+     * below, if vr->term == currentTerm - 1. That, however, would only matter
+     * if we had rejected a previous RequestVote from a third server, who must
+     * have already won a prevote phase. Hence, we choose not to look into
+     * votedFor for simplicity. */
     if (vr->term < raft_get_current_term((void*)me))
         return 0;
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -128,7 +128,7 @@ int raft_delete_entry_from_idx(raft_server_t* me_, raft_index_t idx)
     return log_delete(me->log, idx);
 }
 
-int raft_election_start(raft_server_t* me_)
+void raft_election_start(raft_server_t* me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
 
@@ -136,7 +136,7 @@ int raft_election_start(raft_server_t* me_)
           me->election_timeout_rand, me->timeout_elapsed, me->current_term,
           raft_get_current_idx(me_));
 
-    return raft_become_candidate(me_);
+    raft_become_candidate(me_);
 }
 
 void raft_become_leader(raft_server_t* me_)
@@ -161,24 +161,54 @@ void raft_become_leader(raft_server_t* me_)
     }
 }
 
-int raft_become_candidate(raft_server_t* me_)
+void raft_become_candidate(raft_server_t* me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     int i;
 
     __log(me_, NULL, "becoming candidate");
 
+    raft_set_state(me_, RAFT_STATE_CANDIDATE);
+    me->prevote = 1;
+
+    for (i = 0; i < me->num_nodes; i++)
+        raft_node_vote_for_me(me->nodes[i], 0);
+    raft_node_vote_for_me(raft_get_my_node(me_), 1);
+
+    raft_randomize_election_timeout(me_);
+    me->timeout_elapsed = 0;
+
+    for (i = 0; i < me->num_nodes; i++)
+    {
+        raft_node_t* node = me->nodes[i];
+
+        if (!raft_is_self(me_, node) &&
+            raft_node_is_active(node) &&
+            raft_node_is_voting(node))
+        {
+            raft_send_requestvote(me_, node);
+        }
+    }
+}
+
+int raft_become_prevoted_candidate(raft_server_t* me_)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    int i;
+
+    __log(me_, NULL, "becoming prevoted candidate");
+
+    me->prevote = 0;
     int e = raft_set_current_term(me_, raft_get_current_term(me_) + 1);
     if (0 != e)
         return e;
     for (i = 0; i < me->num_nodes; i++)
         raft_node_vote_for_me(me->nodes[i], 0);
-    raft_vote_for_nodeid(me_, me->node_id);
+    e = raft_vote_for_nodeid(me_, me->node_id);
+    if (0 != e)
+        return e;
+    raft_node_vote_for_me(raft_get_my_node(me_), 1);
     me->leader_id = -1;
-    raft_set_state(me_, RAFT_STATE_CANDIDATE);
-
-    raft_randomize_election_timeout(me_);
-    me->timeout_elapsed = 0;
 
     for (i = 0; i < me->num_nodes; i++)
     {
@@ -239,11 +269,7 @@ int raft_periodic(raft_server_t* me_, int msec_since_last_period)
     {
         if (1 < raft_get_num_voting_nodes(me_) &&
             my_node && raft_node_is_voting(my_node))
-        {
-            int e = raft_election_start(me_);
-            if (0 != e)
-                return e;
-        }
+            raft_election_start(me_);
     }
 
     if (me->last_applied_idx < raft_get_commit_idx(me_) &&
@@ -537,10 +563,14 @@ static int __should_grant_vote(raft_server_private_t* me, msg_requestvote_t* vr)
     if (my_node && !raft_node_is_voting(my_node))
         return 0;
 
+    /* For a prevote, we could proceed to the votedFor check, if
+     * vr->term == currentTerm - 1. That would only matter if we had
+     * rejected a previous RequestVote from a third server, who had
+     * already won a prevote phase. */
     if (vr->term < raft_get_current_term((void*)me))
         return 0;
 
-    if (me->voted_for != -1 && me->voted_for != vr->candidate_id)
+    if (!vr->prevote && me->voted_for != -1 && me->voted_for != vr->candidate_id)
         return 0;
 
     /* Below we check if log is more up-to-date... */
@@ -592,19 +622,21 @@ int raft_recv_requestvote(raft_server_t* me_,
     if (__should_grant_vote(me, vr))
     {
         /* It shouldn't be possible for a leader or candidate to grant a vote
-         * Both states would have voted for themselves */
-        assert(!(raft_is_leader(me_) || raft_is_candidate(me_)));
+         * Both states would have voted for themselves
+         * A candidate may grant a prevote though */
+        assert(!raft_is_leader(me_) && (vr->prevote || !raft_is_candidate(me_)));
 
-        e = raft_vote_for_nodeid(me_, vr->candidate_id);
-        if (0 == e)
-            r->vote_granted = 1;
-        else
-            r->vote_granted = 0;
+        r->vote_granted = 1;
+        if (!vr->prevote)
+        {
+            e = raft_vote_for_nodeid(me_, vr->candidate_id);
+            if (0 != e)
+                r->vote_granted = 0;
 
-        /* there must be in an election. */
-        me->leader_id = -1;
-
-        me->timeout_elapsed = 0;
+            /* there must be in an election. */
+            me->leader_id = -1;
+            me->timeout_elapsed = 0;
+        }
     }
     else
     {
@@ -623,12 +655,14 @@ int raft_recv_requestvote(raft_server_t* me_,
     }
 
 done:
-    __log(me_, node, "node requested vote: %d replying: %s",
+    __log(me_, node, "node requested vote%s: %d replying: %s",
+          vr->prevote ? " (prevote)" : "",
           node == NULL ? -1 : raft_node_get_id(node),
           r->vote_granted == 1 ? "granted" :
           r->vote_granted == 0 ? "not granted" : "unknown");
 
     r->term = raft_get_current_term(me_);
+    r->prevote = vr->prevote;
     return e;
 }
 
@@ -646,11 +680,14 @@ int raft_recv_requestvote_response(raft_server_t* me_,
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
 
-    __log(me_, node, "node responded to requestvote status: %s",
+    __log(me_, node, "node responded to requestvote%s status:%s ct:%ld rt:%ld",
+          r->prevote ? " (prevote)" : "",
           r->vote_granted == 1 ? "granted" :
-          r->vote_granted == 0 ? "not granted" : "unknown");
+          r->vote_granted == 0 ? "not granted" : "unknown",
+          me->current_term,
+          r->term);
 
-    if (!raft_is_candidate(me_))
+    if (!raft_is_candidate(me_) || me->prevote != r->prevote)
     {
         return 0;
     }
@@ -671,12 +708,6 @@ int raft_recv_requestvote_response(raft_server_t* me_,
         return 0;
     }
 
-    __log(me_, node, "node responded to requestvote status:%s ct:%ld rt:%ld",
-          r->vote_granted == 1 ? "granted" :
-          r->vote_granted == 0 ? "not granted" : "unknown",
-          me->current_term,
-          r->term);
-
     switch (r->vote_granted)
     {
         case RAFT_REQUESTVOTE_ERR_GRANTED:
@@ -684,7 +715,12 @@ int raft_recv_requestvote_response(raft_server_t* me_,
                 raft_node_vote_for_me(node, 1);
             int votes = raft_get_nvotes_for_me(me_);
             if (raft_votes_is_majority(raft_get_num_voting_nodes(me_), votes))
-                raft_become_leader(me_);
+            {
+                if (r->prevote)
+                    raft_become_prevoted_candidate(me_);
+                else
+                    raft_become_leader(me_);
+            }
             break;
 
         case RAFT_REQUESTVOTE_ERR_NOT_GRANTED:
@@ -875,12 +911,14 @@ int raft_send_requestvote(raft_server_t* me_, raft_node_t* node)
     assert(node);
     assert(!raft_is_self(me_, node));
 
-    __log(me_, node, "sending requestvote to: %d", raft_node_get_id(node));
+    __log(me_, node, "sending requestvote%s to: %d",
+          me->prevote ? " (prevote)" : "", raft_node_get_id(node));
 
     rv.term = me->current_term;
     rv.last_log_idx = raft_get_current_idx(me_);
     rv.last_log_term = raft_get_last_log_term(me_);
     rv.candidate_id = raft_get_nodeid(me_);
+    rv.prevote = me->prevote;
     if (me->cb.send_requestvote)
         e = me->cb.send_requestvote(me_, me->udata, node, &rv);
     return e;
@@ -1130,17 +1168,13 @@ int raft_get_nvotes_for_me(raft_server_t* me_)
 
     for (i = 0, votes = 0; i < me->num_nodes; i++)
     {
-        if (!raft_is_self(me_, me->nodes[i]) &&
-            raft_node_is_active(me->nodes[i]) &&
+        if (raft_node_is_active(me->nodes[i]) &&
             raft_node_is_voting(me->nodes[i]) &&
             raft_node_has_vote_for_me(me->nodes[i]))
         {
             votes += 1;
         }
     }
-
-    if (me->voted_for == raft_get_nodeid(me_))
-        votes += 1;
 
     return votes;
 }

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -203,6 +203,12 @@ int raft_is_candidate(raft_server_t* me_)
     return raft_get_state(me_) == RAFT_STATE_CANDIDATE;
 }
 
+int raft_is_prevoted_candidate(raft_server_t* me_)
+{
+    raft_server_private_t* me = (void*)me_;
+    return raft_get_state(me_) == RAFT_STATE_CANDIDATE && !me->prevote;
+}
+
 int raft_is_self(raft_server_t* me_, raft_node_t* node)
 {
     raft_server_private_t* me = (void*)me_;

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -261,13 +261,34 @@ void TestRaft_server_remove_node(CuTest * tc)
     CuAssertTrue(tc, NULL == raft_get_node(r, 9));
 }
 
-void TestRaft_election_start_increments_term(CuTest * tc)
+void TestRaft_election_start_does_not_increment_term(CuTest * tc)
 {
     void *r = raft_new();
     raft_set_callbacks(r, &generic_funcs, NULL);
+    raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
     raft_set_current_term(r, 1);
     raft_election_start(r);
+    CuAssertTrue(tc, 1 == raft_get_current_term(r));
+    CuAssertTrue(tc, raft_is_candidate(r));
+    CuAssertTrue(tc, 1 == raft_get_nvotes_for_me(r));
+}
+
+void TestRaft_become_prevoted_candidate_increments_term(CuTest * tc)
+{
+    void *r = raft_new();
+    raft_set_callbacks(r, &generic_funcs, NULL);
+    raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
+    raft_set_current_term(r, 1);
+    raft_become_candidate(r);
+    CuAssertTrue(tc, 1 == raft_get_current_term(r));
+    CuAssertTrue(tc, raft_is_candidate(r));
+    CuAssertTrue(tc, 1 == raft_get_nvotes_for_me(r));
+    raft_become_prevoted_candidate(r);
     CuAssertTrue(tc, 2 == raft_get_current_term(r));
+    CuAssertTrue(tc, raft_is_candidate(r));
+    CuAssertTrue(tc, 1 == raft_get_nvotes_for_me(r));
 }
 
 void TestRaft_set_state(CuTest * tc)
@@ -797,6 +818,42 @@ void TestRaft_server_recv_requestvote_response_dont_increase_votes_for_me_when_t
     CuAssertTrue(tc, 0 == raft_get_nvotes_for_me(r));
 }
 
+void TestRaft_server_recv_prevote_response_increase_prevotes_for_me(
+    CuTest * tc
+    )
+{
+    raft_cbs_t funcs = {
+        .persist_term = __raft_persist_term,
+        .persist_vote = __raft_persist_vote,
+        .send_requestvote = __raft_send_requestvote,
+        .send_appendentries = __raft_send_appendentries,
+    };
+
+    void *r = raft_new();
+    raft_set_callbacks(r, &funcs, NULL);
+
+    raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
+    raft_set_current_term(r, 1);
+    CuAssertTrue(tc, 0 == raft_get_nvotes_for_me(r));
+    CuAssertIntEquals(tc, 1, raft_get_current_term(r));
+
+    raft_become_candidate(r);
+    CuAssertIntEquals(tc, 1, raft_get_current_term(r));
+    CuAssertIntEquals(tc, 1, raft_get_nvotes_for_me(r));
+
+    msg_requestvote_response_t rvr;
+    memset(&rvr, 0, sizeof(msg_requestvote_response_t));
+    rvr.term = 1;
+    rvr.vote_granted = 1;
+    rvr.prevote = 1;
+    int e = raft_recv_requestvote_response(r, raft_get_node(r, 2), &rvr);
+    CuAssertIntEquals(tc, 0, e);
+    /* got 2 prevotes, became prevoted candidate, incremented term, and voted for self */
+    CuAssertIntEquals(tc, 2, raft_get_current_term(r));
+    CuAssertIntEquals(tc, 1, raft_get_nvotes_for_me(r));
+}
+
 void TestRaft_server_recv_requestvote_response_increase_votes_for_me(
     CuTest * tc
     )
@@ -818,6 +875,7 @@ void TestRaft_server_recv_requestvote_response_increase_votes_for_me(
     CuAssertIntEquals(tc, 1, raft_get_current_term(r));
 
     raft_become_candidate(r);
+    raft_become_prevoted_candidate(r);
     CuAssertIntEquals(tc, 2, raft_get_current_term(r));
     CuAssertTrue(tc, 1 == raft_get_nvotes_for_me(r));
 
@@ -828,6 +886,37 @@ void TestRaft_server_recv_requestvote_response_increase_votes_for_me(
     int e = raft_recv_requestvote_response(r, raft_get_node(r, 2), &rvr);
     CuAssertIntEquals(tc, 0, e);
     CuAssertTrue(tc, 2 == raft_get_nvotes_for_me(r));
+}
+
+void TestRaft_server_recv_prevote_response_must_be_candidate_to_receive(
+    CuTest * tc
+    )
+{
+    raft_cbs_t funcs = {
+        .persist_term = __raft_persist_term,
+        .persist_vote = __raft_persist_vote,
+        .send_appendentries = __raft_send_appendentries,
+    };
+
+    void *r = raft_new();
+    raft_set_callbacks(r, &funcs, NULL);
+
+    raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
+    raft_set_current_term(r, 1);
+    CuAssertIntEquals(tc, 0, raft_get_nvotes_for_me(r));
+
+    raft_become_candidate(r);
+    raft_become_prevoted_candidate(r);
+    CuAssertIntEquals(tc, 1, raft_get_nvotes_for_me(r));
+
+    msg_requestvote_response_t rvr;
+    memset(&rvr, 0, sizeof(msg_requestvote_response_t));
+    rvr.term = 1;
+    rvr.vote_granted = 1;
+    rvr.prevote = 1;
+    raft_recv_requestvote_response(r, raft_get_node(r, 2), &rvr);
+    CuAssertIntEquals(tc, 1, raft_get_nvotes_for_me(r));
 }
 
 void TestRaft_server_recv_requestvote_response_must_be_candidate_to_receive(
@@ -884,6 +973,7 @@ void TestRaft_server_recv_requestvote_reply_false_if_term_less_than_current_term
     int e = raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
     CuAssertIntEquals(tc, 0, e);
     CuAssertIntEquals(tc, 0, rvr.vote_granted);
+    CuAssertIntEquals(tc, 0, rvr.prevote);
 }
 
 void TestRaft_leader_recv_requestvote_does_not_step_down(
@@ -945,6 +1035,46 @@ void TestRaft_server_recv_requestvote_reply_true_if_term_greater_than_or_equal_t
     CuAssertTrue(tc, 1 == rvr.vote_granted);
 }
 
+void TestRaft_server_recv_prevote_dont_grant_real_vote(
+    CuTest * tc
+    )
+{
+    msg_requestvote_t rv;
+    msg_requestvote_response_t rvr;
+
+    raft_cbs_t funcs = {
+        .persist_term = __raft_persist_term,
+        .persist_vote = __raft_persist_vote,
+    };
+
+    void *r = raft_new();
+    raft_set_callbacks(r, &funcs, NULL);
+
+    raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
+    raft_set_current_term(r, 1);
+
+    raft_set_election_timeout(r, 1000);
+    raft_periodic(r, 900);
+
+    /* grant prevote but not real vote */
+    memset(&rv, 0, sizeof(msg_requestvote_t));
+    rv.term = 2;
+    rv.last_log_idx = 1;
+    rv.candidate_id = 2;
+    rv.prevote = 1;
+    raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
+    CuAssertTrue(tc, 1 == rvr.vote_granted);
+    CuAssertIntEquals(tc, 0, raft_get_timeout_elapsed(r));
+    CuAssertIntEquals(tc, -1, raft_get_voted_for(r));
+
+    /* grant real vote as advertised */
+    rv.prevote = 0;
+    raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
+    CuAssertTrue(tc, 1 == rvr.vote_granted);
+    CuAssertIntEquals(tc, 2, raft_get_voted_for(r));
+}
+
 void TestRaft_server_recv_requestvote_reset_timeout(
     CuTest * tc
     )
@@ -991,6 +1121,7 @@ void TestRaft_server_recv_requestvote_candidate_step_down_if_term_is_higher_than
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
     raft_become_candidate(r);
+    raft_become_prevoted_candidate(r);
     raft_set_current_term(r, 1);
     CuAssertIntEquals(tc, 1, raft_get_voted_for(r));
 
@@ -1023,6 +1154,7 @@ void TestRaft_server_recv_requestvote_depends_on_candidate_id(
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
     raft_become_candidate(r);
+    raft_become_prevoted_candidate(r);
     raft_set_current_term(r, 1);
     CuAssertIntEquals(tc, 1, raft_get_voted_for(r));
 
@@ -1076,6 +1208,47 @@ void TestRaft_server_recv_requestvote_dont_grant_vote_if_we_didnt_vote_for_this_
     rv.candidate_id = 2;
     raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
     CuAssertTrue(tc, 0 == rvr.vote_granted);
+}
+
+/* If prevote is received within the minimum election timeout of
+ * hearing from a current leader, it does not update its term or grant its
+ * prevote (§4.2.3, §9.6).
+ */
+void TestRaft_server_recv_prevote_ignore_if_master_is_fresh(CuTest * tc)
+{
+    raft_cbs_t funcs = { 0
+    };
+
+    void *r = raft_new();
+    raft_set_callbacks(r, &funcs, NULL);
+
+    raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
+    raft_set_current_term(r, 1);
+    raft_set_election_timeout(r, 1000);
+
+    msg_appendentries_t ae = { 0 };
+    msg_appendentries_response_t aer;
+    ae.term = 1;
+
+    raft_recv_appendentries(r, raft_get_node(r, 2), &ae, &aer);
+    CuAssertTrue(tc, 1 == aer.success);
+
+    msg_requestvote_t rv = { 
+        .term = 2,
+        .candidate_id = 3,
+        .last_log_idx = 0,
+        .last_log_term = 1,
+        .prevote = 1
+    };
+    msg_requestvote_response_t rvr;
+    raft_recv_requestvote(r, raft_get_node(r, 3), &rv, &rvr);
+    CuAssertTrue(tc, 1 != rvr.vote_granted);
+
+    /* After election timeout passed, the same prevote should be accepted */
+    raft_periodic(r, 1001);
+    raft_recv_requestvote(r, raft_get_node(r, 3), &rv, &rvr);
+    CuAssertTrue(tc, 1 == rvr.vote_granted);
 }
 
 /* If requestvote is received within the minimum election timeout of
@@ -1911,6 +2084,61 @@ void TestRaft_follower_becomes_candidate_when_election_timeout_occurs(
     CuAssertTrue(tc, 1 == raft_is_candidate(r));
 }
 
+void TestRaft_follower_dont_grant_prevote_if_candidate_has_a_less_complete_log(
+    CuTest * tc)
+{
+    msg_requestvote_t rv;
+    msg_requestvote_response_t rvr;
+
+    raft_cbs_t funcs = {
+        .persist_term = __raft_persist_term,
+        .persist_vote = __raft_persist_vote,
+    };
+
+    void *r = raft_new();
+    raft_set_callbacks(r, &funcs, NULL);
+
+    raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
+
+    /*  request prevote */
+    /*  prevote indicates candidate's log is not complete compared to follower */
+    memset(&rv, 0, sizeof(msg_requestvote_t));
+    rv.term = 1;
+    rv.candidate_id = 1;
+    rv.last_log_idx = 1;
+    rv.last_log_term = 1;
+    rv.prevote = 1;
+
+    raft_set_current_term(r, 1);
+
+    /* server's idx are more up-to-date */
+    raft_entry_t ety = {};
+    ety.term = 1;
+    ety.id = 100;
+    ety.data.len = 4;
+    ety.data.buf = (unsigned char*)"aaa";
+    raft_append_entry(r, &ety);
+    ety.id = 101;
+    ety.term = 2;
+    raft_append_entry(r, &ety);
+
+    /* prevote not granted */
+    raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
+    CuAssertTrue(tc, 0 == rvr.vote_granted);
+
+    /* approve vote, because last_log_term is higher */
+    raft_set_current_term(r, 2);
+    memset(&rv, 0, sizeof(msg_requestvote_t));
+    rv.term = 2;
+    rv.candidate_id = 1;
+    rv.last_log_idx = 1;
+    rv.last_log_term = 3;
+    rv.prevote = 1;
+    raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
+    CuAssertIntEquals(tc, 1, rvr.vote_granted);
+}
+
 /* Candidate 5.2 */
 void TestRaft_follower_dont_grant_vote_if_candidate_has_a_less_complete_log(
     CuTest * tc)
@@ -2137,6 +2365,7 @@ void TestRaft_candidate_becomes_candidate_is_candidate(CuTest * tc)
 
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
+    raft_add_node(r, NULL, 1, 1);
 
     raft_become_candidate(r);
     CuAssertTrue(tc, raft_is_candidate(r));
@@ -2152,9 +2381,12 @@ void TestRaft_follower_becoming_candidate_increments_current_term(CuTest * tc)
 
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
+    raft_add_node(r, NULL, 1, 1);
 
     CuAssertTrue(tc, 0 == raft_get_current_term(r));
     raft_become_candidate(r);
+    CuAssertTrue(tc, 0 == raft_get_current_term(r));
+    raft_become_prevoted_candidate(r);
     CuAssertTrue(tc, 1 == raft_get_current_term(r));
 }
 
@@ -2172,6 +2404,7 @@ void TestRaft_follower_becoming_candidate_votes_for_self(CuTest * tc)
     raft_add_node(r, NULL, 1, 1);
     CuAssertTrue(tc, -1 == raft_get_voted_for(r));
     raft_become_candidate(r);
+    raft_become_prevoted_candidate(r);
     CuAssertTrue(tc, raft_get_nodeid(r) == raft_get_voted_for(r));
     CuAssertTrue(tc, 1 == raft_get_nvotes_for_me(r));
 }
@@ -2186,6 +2419,8 @@ void TestRaft_follower_becoming_candidate_resets_election_timeout(CuTest * tc)
 
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
+    raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
 
     raft_set_election_timeout(r, 1000);
     CuAssertTrue(tc, 0 == raft_get_timeout_elapsed(r));
@@ -2245,18 +2480,33 @@ void TestRaft_follower_becoming_candidate_requests_votes_from_other_servers(
     /* set term so we can check it gets included in the outbound message */
     raft_set_current_term(r, 2);
 
-    /* becoming candidate triggers vote requests */
+    /* becoming candidate triggers prevote requests */
     raft_become_candidate(r);
+
+    /* 2 nodes = 2 prevote requests */
+    rv = sender_poll_msg_data(sender);
+    CuAssertTrue(tc, NULL != rv);
+    CuAssertTrue(tc, 2 == rv->term);
+    CuAssertTrue(tc, rv->prevote);
+    /*  TODO: there should be more items */
+    rv = sender_poll_msg_data(sender);
+    CuAssertTrue(tc, NULL != rv);
+    CuAssertTrue(tc, 2 == rv->term);
+    CuAssertTrue(tc, rv->prevote);
+
+    /* becoming candidate triggers vote requests */
+    raft_become_prevoted_candidate(r);
 
     /* 2 nodes = 2 vote requests */
     rv = sender_poll_msg_data(sender);
     CuAssertTrue(tc, NULL != rv);
-    CuAssertTrue(tc, 2 != rv->term);
     CuAssertTrue(tc, 3 == rv->term);
+    CuAssertTrue(tc, !rv->prevote);
     /*  TODO: there should be more items */
     rv = sender_poll_msg_data(sender);
     CuAssertTrue(tc, NULL != rv);
     CuAssertTrue(tc, 3 == rv->term);
+    CuAssertTrue(tc, !rv->prevote);
 }
 
 /* Candidate 5.2 */
@@ -2283,11 +2533,12 @@ void TestRaft_candidate_election_timeout_and_no_leader_results_in_new_election(
 
     /* server wants to be leader, so becomes candidate */
     raft_become_candidate(r);
+    raft_become_prevoted_candidate(r);
     CuAssertTrue(tc, 1 == raft_get_current_term(r));
 
     /* clock over (ie. max election timeout + 1), causing new election */
     raft_periodic(r, max_election_timeout(1000) + 1);
-    CuAssertTrue(tc, 2 == raft_get_current_term(r));
+    CuAssertTrue(tc, raft_is_candidate(r));
 
     /*  receiving this vote gives the server majority */
 //    raft_recv_requestvote_response(r,1,&vr);
@@ -2318,6 +2569,7 @@ void TestRaft_candidate_receives_majority_of_votes_becomes_leader(CuTest * tc)
 
     /* vote for self */
     raft_become_candidate(r);
+    raft_become_prevoted_candidate(r);
     CuAssertTrue(tc, 1 == raft_get_current_term(r));
     CuAssertTrue(tc, 1 == raft_get_nvotes_for_me(r));
 
@@ -2434,6 +2686,45 @@ void TestRaft_candidate_recv_requestvote_response_becomes_follower_if_current_te
     CuAssertTrue(tc, -1 == raft_get_voted_for(r));
 }
 
+/* Test the assertion after the __should_grant_vote call in
+ * raft_recv_requestvote. */
+void TestRaft_candidate_may_grant_prevote_if_term_not_less_than_current_term(
+    CuTest * tc)
+{
+    raft_cbs_t funcs = {
+        .persist_term = __raft_persist_term,
+        .persist_vote = __raft_persist_vote,
+    };
+
+    void *r = raft_new();
+    raft_set_callbacks(r, &funcs, NULL);
+
+    raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
+
+    raft_set_current_term(r, 1);
+    raft_become_candidate(r);
+
+    /* prevoting candidate may grant prevote */
+    msg_requestvote_t rv;
+    msg_requestvote_response_t rvr;
+    memset(&rv, 0, sizeof(msg_requestvote_t));
+    rv.term = 1;
+    rv.prevote = 1;
+    raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
+    CuAssertTrue(tc, rvr.vote_granted);
+
+    raft_become_prevoted_candidate(r);
+    CuAssertIntEquals(tc, 2, raft_get_current_term(r));
+
+    /* prevoted candidate may grant prevote */
+    rv.term = 2;
+    rv.prevote = 1;
+    memset(&rvr, 0, sizeof(msg_requestvote_response_t));
+    raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
+    CuAssertTrue(tc, rvr.vote_granted);
+}
+
 /* Candidate 5.2 */
 void TestRaft_candidate_recv_appendentries_frm_leader_results_in_follower(
     CuTest * tc)
@@ -2469,7 +2760,6 @@ void TestRaft_candidate_recv_appendentries_frm_leader_results_in_follower(
     CuAssertTrue(tc, -1 == raft_get_voted_for(r));
 }
 
-/* Candidate 5.2 */
 void TestRaft_candidate_recv_appendentries_from_same_term_results_in_step_down(
     CuTest * tc)
 {
@@ -2490,6 +2780,40 @@ void TestRaft_candidate_recv_appendentries_from_same_term_results_in_step_down(
 
     raft_set_current_term(r, 1);
     raft_become_candidate(r);
+    CuAssertTrue(tc, raft_is_candidate(r));
+    CuAssertIntEquals(tc, -1, raft_get_voted_for(r));
+
+    memset(&ae, 0, sizeof(msg_appendentries_t));
+    ae.term = 2;
+    ae.prev_log_idx = 1;
+    ae.prev_log_term = 1;
+
+    raft_recv_appendentries(r, raft_get_node(r, 2), &ae, &aer);
+    CuAssertTrue(tc, 0 == raft_is_candidate(r));
+}
+
+/* Candidate 5.2 */
+void TestRaft_prevoted_candidate_recv_appendentries_from_same_term_results_in_step_down(
+    CuTest * tc)
+{
+    raft_cbs_t funcs = {
+        .persist_term = __raft_persist_term,
+        .persist_vote = __raft_persist_vote,
+        .send_requestvote = __raft_send_requestvote,
+    };
+
+    void *r = raft_new();
+    raft_set_callbacks(r, &funcs, NULL);
+
+    msg_appendentries_t ae;
+    msg_appendentries_response_t aer;
+
+    raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
+
+    raft_set_current_term(r, 1);
+    raft_become_candidate(r);
+    raft_become_prevoted_candidate(r);
     CuAssertTrue(tc, 0 == raft_is_follower(r));
     CuAssertIntEquals(tc, 1, raft_get_voted_for(r));
 
@@ -3915,6 +4239,44 @@ void TestRaft_leader_sends_empty_appendentries_every_request_timeout(
 void T_estRaft_leader_sends_appendentries_when_receive_entry_msg(CuTest * tc)
 #endif
 
+void TestRaft_leader_recv_prevote_responds_without_granting(CuTest * tc)
+{
+    raft_cbs_t funcs = {
+        .persist_vote = __raft_persist_vote,
+        .persist_term = __raft_persist_term,
+        .send_requestvote = __raft_send_requestvote,
+        .send_appendentries = sender_appendentries,
+    };
+
+    void *sender = sender_new(NULL);
+    void *r = raft_new();
+    raft_set_callbacks(r, &funcs, sender);
+    raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
+    raft_add_node(r, NULL, 3, 0);
+    raft_set_election_timeout(r, 1000);
+    raft_set_request_timeout(r, 500);
+    CuAssertTrue(tc, 0 == raft_get_timeout_elapsed(r));
+
+    raft_become_candidate(r);
+    raft_become_prevoted_candidate(r);
+
+    msg_requestvote_response_t rvr;
+    memset(&rvr, 0, sizeof(msg_requestvote_response_t));
+    rvr.term = 1;
+    rvr.vote_granted = 1;
+    raft_recv_requestvote_response(r, raft_get_node(r, 2), &rvr);
+    CuAssertTrue(tc, 1 == raft_is_leader(r));
+
+    /* receive request vote from node 3 */
+    msg_requestvote_t rv;
+    memset(&rv, 0, sizeof(msg_requestvote_t));
+    rv.term = 1;
+    rv.prevote = 1;
+    raft_recv_requestvote(r, raft_get_node(r, 3), &rv, &rvr);
+    CuAssertTrue(tc, 0 == rvr.vote_granted);
+}
+
 void TestRaft_leader_recv_requestvote_responds_without_granting(CuTest * tc)
 {
     raft_cbs_t funcs = {
@@ -3934,7 +4296,8 @@ void TestRaft_leader_recv_requestvote_responds_without_granting(CuTest * tc)
     raft_set_request_timeout(r, 500);
     CuAssertTrue(tc, 0 == raft_get_timeout_elapsed(r));
 
-    raft_election_start(r);
+    raft_become_candidate(r);
+    raft_become_prevoted_candidate(r);
 
     msg_requestvote_response_t rvr;
     memset(&rvr, 0, sizeof(msg_requestvote_response_t));


### PR DESCRIPTION
Add the Pre-Vote phase (§4.2.3, §9.6) before a candidate increments the
term, in order to prevent an isolated server from disrupting an existing
leader when the isolation ends.

A prevote field is added to both msg_requestvote_t and
msg_requestvote_response_t. Users may need to make code changes,
depending on how they transfer these messages.

The Pre-Vote phase is implemented as a substate, determined by
raft_server_private_t.prevote, in RAFT_STATE_CANDIDATE. A candidate
first enters the Pre-Vote phase (raft_server_private_t.prevote == 1),
requesting "prevotes". It's called a prevoting candidate in a few
places. If this candidate wins the Pre-Vote phase, it becomes a
"prevoted" candidate (raft_server_private_t.prevote == 0), requesting
(normal) votes.

A prevote request is evaluated against the term and log states, but not
the vote state, for simplicity. See the comment in __should_grant_vote
for the case being sacrificed.

Granted prevotes are tracked using RAFT_NODE_VOTED_FOR_ME flags. When a
candidate becomes a prevoted candidate, it clears all those flags and
uses them to track (normal) votes. Prevotes and votes from a server
itself are now tracked in the same way as those from other servers are,
because using voted_for and prevote fields in raft_server_private_t
seems to make things trickier. This change also leads to the fixes for a
few tests where a server becomes a candidate with an empty membership.

Signed-off-by: Li Wei <wei.g.li@intel.com>