### PR TITLE
DAOS-8023 server: Clear leader_id before prevote

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -175,6 +175,7 @@ void raft_become_candidate(raft_server_t* me_)
         raft_node_vote_for_me(me->nodes[i], 0);
     raft_node_vote_for_me(raft_get_my_node(me_), 1);
 
+    me->leader_id = -1;
     raft_randomize_election_timeout(me_);
     me->timeout_elapsed = 0;
 
@@ -208,7 +209,6 @@ int raft_become_prevoted_candidate(raft_server_t* me_)
     if (0 != e)
         return e;
     raft_node_vote_for_me(raft_get_my_node(me_), 1);
-    me->leader_id = -1;
 
     for (i = 0; i < me->num_nodes; i++)
     {

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -2713,6 +2713,40 @@ void TestRaft_candidate_may_grant_prevote_if_term_not_less_than_current_term(
     CuAssertTrue(tc, rvr.vote_granted);
 }
 
+/* Candidates do not reject prevote based on leader liveness checks. Once upon
+ * a time, they did, because leader_id values were cleared only after the
+ * prevote phase. */
+void TestRaft_candidate_grant_prevote(
+    CuTest * tc)
+{
+    void *r = raft_new();
+    raft_set_callbacks(r, &generic_funcs, NULL);
+
+    raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
+    raft_add_node(r, NULL, 3, 0);
+
+    /* receive AE from leader */
+    msg_appendentries_t ae;
+    memset(&ae, 0, sizeof(msg_appendentries_t));
+    ae.term = 1;
+    msg_appendentries_response_t aer;
+    raft_recv_appendentries(r, raft_get_node(r, 2), &ae, &aer);
+    CuAssertTrue(tc, aer.success);
+    CuAssertIntEquals(tc, 2, raft_get_current_leader(r));
+
+    raft_become_candidate(r);
+
+    /* candidate grants prevote */
+    msg_requestvote_t rv;
+    msg_requestvote_response_t rvr;
+    memset(&rv, 0, sizeof(msg_requestvote_t));
+    rv.term = 1;
+    rv.prevote = 1;
+    raft_recv_requestvote(r, raft_get_node(r, 3), &rv, &rvr);
+    CuAssertTrue(tc, rvr.vote_granted);
+}
+
 /* Candidate 5.2 */
 void TestRaft_candidate_recv_appendentries_frm_leader_results_in_follower(
     CuTest * tc)


### PR DESCRIPTION
35d1029 clears leader_id after the Pre-Vote phase. That is too late,
because incoming RequestVote requests will be rejected during a minimum
election timeout from the beginning of the election, by the leader
aliveness check in raft_recv_requestvote. The leader_id should be
cleared as soon as a candidate resets timeout_elapsed.

Signed-off-by: Li Wei <wei.g.li@intel.com>