### PR TITLE
DAOS-7721 server: Fix IS performance

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+raft (0.8.1-1) unstable; urgency=medium
+
+  [ Li Wei ]
+  * Optimize InstallSnapshot performance
+  * Update packaging
+
+ -- Li Wei <wei.g.li@intel.com>  Mon, Aug 30 2021 17:47:00 +0800
+
 raft (0.8.0-1) unstable; urgency=medium
 
   [ Li Wei ]

--- a/packaging/Dockerfile.centos.7
+++ b/packaging/Dockerfile.centos.7
@@ -17,7 +17,7 @@ ARG UID=1000
 # Install basic tools
 RUN yum install -y epel-release
 RUN yum install -y mock make rpm-build curl createrepo rpmlint redhat-lsb-core \
-                   git python-srpm-macros
+                   git python-srpm-macros dnf
 
 # Add build user (to keep rpmbuild happy)
 ENV USER build

--- a/packaging/Dockerfile.centos.7
+++ b/packaging/Dockerfile.centos.7
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2020, Intel Corporation
+# Copyright 2018-2021, Intel Corporation
 #
 # 'recipe' for Docker to build an RPM
 #

--- a/packaging/Dockerfile.coverity
+++ b/packaging/Dockerfile.coverity
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2019, Intel Corporation
+# Copyright 2018-2020, Intel Corporation
 #
 # 'recipe' for Docker to build for a Coverity scan.
 #

--- a/packaging/Dockerfile.mockbuild
+++ b/packaging/Dockerfile.mockbuild
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2020, Intel Corporation
+# Copyright 2018-2021, Intel Corporation
 #
 # 'recipe' for Docker to build an RPM
 #

--- a/packaging/Dockerfile.ubuntu.20.04
+++ b/packaging/Dockerfile.ubuntu.20.04
@@ -1,11 +1,11 @@
 #
-# Copyright 2019-2020, Intel Corporation
+# Copyright 2019-2021, Intel Corporation
 #
 # 'recipe' for Docker to build an Debian package
 #
 # Pull base image
 FROM ubuntu:20.04
-MAINTAINER daos-stack <daos@daos.groups.io>
+LABEL org.opencontainers.image.authors="daos@daos.groups.io"
 
 # use same UID as host and default value of 1000 if not specified
 ARG UID=1000
@@ -14,10 +14,10 @@ ARG REPO_UBUNTU_20_04=""
 
 # Install basic tools
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-            autoconf bash curl debhelper dh-make dpkg-dev doxygen gcc   \
-            git git-buildpackage locales make patch pbuilder rpm wget   \
-            ca-certificates scons python3-distutils pkg-config          \
-            python3-dev python3-distro
+            autoconf bash ca-certificates curl debhelper dh-make        \
+            dpkg-dev dh-python doxygen gcc git git-buildpackage locales \
+            make patch pbuilder pkg-config python3-dev python3-distro   \
+            python3-distutils rpm scons wget
 
 # rpmdevtools
 RUN echo "deb [trusted=yes] ${REPO_URL}${REPO_UBUNTU_20_04} focal main" > /etc/apt/sources.list.d/daos-stack-ubuntu-stable-local.list

--- a/packaging/Makefile_distro_vars.mk
+++ b/packaging/Makefile_distro_vars.mk
@@ -38,18 +38,33 @@ DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
 VERSION_ID  := 8
 DISTRO_ID   := el8
 DISTRO_BASE := EL_8
+ifeq ($(DAOS_STACK_CENTOS_8_VERSION),8.$(DOT_VER))
+DAOS_REPO_TYPE ?= STABLE
+else
+DAOS_REPO_TYPE ?= DEV
+endif
 SED_EXPR    := 1s/$(DIST)//p
 endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.2-x86_64)
 VERSION_ID  := 15.2
 DISTRO_ID   := sl15.2
 DISTRO_BASE := LEAP_15
+ifeq ($(DAOS_STACK_LEAP_15_VERSION),15.2)
+DAOS_REPO_TYPE ?= STABLE
+else
+DAOS_REPO_TYPE ?= DEV
+endif
 SED_EXPR    := 1p
 endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.3-x86_64)
 VERSION_ID  := 15.3
 DISTRO_ID   := sl15.3
 DISTRO_BASE := LEAP_15
+ifeq ($(DAOS_STACK_LEAP_15_VERSION),15.3)
+DAOS_REPO_TYPE ?= STABLE
+else
+DAOS_REPO_TYPE ?= DEV
+endif
 SED_EXPR    := 1p
 endif
 endif

--- a/packaging/rpm_chrootbuild
+++ b/packaging/rpm_chrootbuild
@@ -7,8 +7,32 @@ IFS=\| read -r -a distro_base_local_repos <<< "$DISTRO_BASE_LOCAL_REPOS"
 repo_adds=()
 repo_dels=()
 
+
+
+
+: "${DISTRO_NAME:=$DISTRO}"
+if [[ "${CHROOT_NAME}" = epel-8-* ]]; then
+    : "${DAOS_STACK_CENTOS_8_VERSION:=8}"
+    DISTRO_NAME="centos-${DAOS_STACK_CENTOS_8_VERSION}"
+elif [[ "${CHROOT_NAME}" = opensuse-leap-15* ]]; then
+    : "${DAOS_STACK_LEAP_15_VERSION:=15.3}"
+    DISTRO_NAME="opensuse-${DAOS_STACK_LEAP_15_VERSION}"
+fi
+: "${REPOSITORY_URL:=}"
 if [ -n "$REPOSITORY_URL" ] && [ -n "$DISTRO_REPOS" ]; then
     repo_dels+=("--disablerepo=\*")
+elif [ "${CHROOT_NAME}" == "epel-8-x86_64" ]; then
+    # Special code to force building on CentOS 8.3
+    if [ "${DOT_VER}" -eq 3 ]; then
+        repo_dels+=("--disablerepo=\*")
+        repo_base='http://mirror.centos.org/centos/8.3.2011/'
+        distro_base_local_repos=(\
+"${repo_base}BaseOS/x86_64/os/" \
+"${repo_base}AppStream/x86_64/os/" \
+"${repo_base}extras/x86_64/os/" \
+"${repo_base}PowerTools/x86_64/os/" \
+https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/ )
+    fi
 fi
 
 : "${WORKSPACE:=$PWD}"
@@ -21,6 +45,13 @@ ln -sf /etc/mock/logging.ini "$mock_config_dir/"
 
 cp "$original_cfg_file" "$cfg_file"
 
+if [ "${CHROOT_NAME}" == "epel-8-x86_64" ]; then
+  echo -e "config_opts['module_enable'] = ['javapackages-tools:201801']" \
+       >> "$cfg_file"
+  if [ -n "${DOT_VER}" ]; then
+    echo -e "config_opts['macros']['%dist'] = '.el8_${DOT_VER}'" >> "$cfg_file"
+  fi
+fi
 echo -e "config_opts['yum.conf'] += \"\"\"\n" >> "$cfg_file"
 for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
     branch="master"
@@ -36,7 +67,7 @@ for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
     repo_adds+=("--enablerepo $repo:$branch:$build_number")
     echo -e "[$repo:$branch:$build_number]\n\
 name=$repo:$branch:$build_number\n\
-baseurl=${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/$DISTRO/\n\
+baseurl=${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/$DISTRO_NAME/\n\
 enabled=1\n\
 gpgcheck=False\n" >> "$cfg_file"
 done
@@ -55,3 +86,6 @@ echo "\"\"\"" >> "$cfg_file"
 eval mock --configdir "$mock_config_dir" -r "${CHROOT_NAME}_daos" \
      "${repo_dels[*]}" "${repo_adds[*]}" \
      $MOCK_OPTIONS $RPM_BUILD_OPTIONS "$TARGET"
+
+# For now just do an advisory check
+rpmlint "/var/lib/mock/${CHROOT_NAME}/result/"*.rpm || true

--- a/raft.spec
+++ b/raft.spec
@@ -9,7 +9,7 @@
 %global debug_package %{nil}
 
 Name:		raft
-Version:	0.8.0
+Version:	0.8.1
 Release:	1%{?relval}%{?dist}
 
 Summary:	C implementation of the Raft Consensus protocol, BSD licensed
@@ -61,6 +61,10 @@ cp -a include/* %{buildroot}/%{_includedir}
 
 
 %changelog
+* Mon Aug 30 2021 Li Wei <wei.g.li@intel.com> -0.8.1-1
+- Optimize InstallSnapshot performance
+- Update packaging
+
 * Mon May 31 2021 Li Wei <wei.g.li@intel.com> -0.8.0-1
 - Add Pre-Vote
 - Set version-release for daos-raft* packages

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -825,11 +825,8 @@ int raft_recv_installsnapshot_response(raft_server_t* me_,
     if (0 != e)
         return e;
 
-    if (!r->complete)
-        return 0;
-
     /* The snapshot installation is complete. Update the node state. */
-    if (raft_node_get_match_idx(node) < r->last_idx)
+    if (r->complete && raft_node_get_match_idx(node) < r->last_idx)
     {
         raft_node_set_match_idx(node, r->last_idx);
         raft_node_set_next_idx(node, r->last_idx + 1);


### PR DESCRIPTION
raft_recv_installsnapshot_response returns immediately if the whole
snapshot has not yet been transferred completely. This causes next chunk
to be sent after an unnecessary request_timeout. The function should
instead continue the execution, skip the node state update, and see if
there is a new chunk to send immediately.

Signed-off-by: Li Wei <wei.g.li@intel.com>