### PR TITLE
DAOS-4689 contrib: Add CLinkedListQueue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 *.gcda
 tests/main_test.c
 tests_main
-CLinkedListQueue
 raft_server.c.gcov
 *~
 libcraft.so

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CONTRIB_DIR = .
+CONTRIB_DIR = contrib
 TEST_DIR = ./tests
 LLQUEUE_DIR = $(CONTRIB_DIR)/CLinkedListQueue
 VPATH = src
@@ -36,18 +36,7 @@ $(BUILDDIR):
 $(BUILDDIR)/%.o: %.c $(wildcard include/*.h) | $(BUILDDIR)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-clinkedlistqueue:
-	mkdir -p $(LLQUEUE_DIR)/.git
-	git --git-dir=$(LLQUEUE_DIR)/.git init 
-	pushd $(LLQUEUE_DIR); git pull http://github.com/willemt/CLinkedListQueue master; popd
-
-download-contrib: clinkedlistqueue
-
 $(TEST_DIR)/main_test.c: $(TEST_DIR)/test_*.c
-	if test -d $(LLQUEUE_DIR); \
-	then echo have contribs; \
-	else make download-contrib; \
-	fi
 	cd $(TEST_DIR) && sh make-tests.sh "test_*.c" > main_test.c && cd ..
 
 .PHONY: shared

--- a/contrib/CLinkedListQueue/Makefile
+++ b/contrib/CLinkedListQueue/Makefile
@@ -1,0 +1,20 @@
+GCOV_OUTPUT = *.gcda *.gcno *.gcov 
+GCOV_CCFLAGS = -fprofile-arcs -ftest-coverage
+CC     = gcc
+CCFLAGS = -I. -Itests -g -O2 -Wall -Werror -W -fno-omit-frame-pointer -fno-common -fsigned-char $(GCOV_CCFLAGS)
+
+all: test
+
+main.c:
+	sh tests/make-tests.sh tests/test_*.c > main.c
+
+test: main.c linked_list_queue.o tests/test_linked_list_queue.c tests/CuTest.c main.c
+	$(CC) $(CCFLAGS) -o $@ $^
+	./test
+	gcov main.c linked_list_queue.c
+
+linked_list_queue.o: linked_list_queue.c
+	$(CC) $(CCFLAGS) -c -o $@ $^
+
+clean:
+	rm -f main.c linked_list_queue.o test $(GCOV_OUTPUT)

--- a/contrib/CLinkedListQueue/README.md
+++ b/contrib/CLinkedListQueue/README.md
@@ -1,0 +1,21 @@
+# How does it work?
+
+```c
+
+char* obj = strdup("test");
+
+void *q = llqueue_new();
+
+llqueue_offer(q, obj);
+
+printf("object from queue: %s\n", llqueue_poll(q));
+
+```
+
+# Building
+$make
+
+# Todo
+
+- Make lockfree variant using CAS
+

--- a/contrib/CLinkedListQueue/linked_list_queue.c
+++ b/contrib/CLinkedListQueue/linked_list_queue.c
@@ -1,0 +1,224 @@
+/*
+ 
+Copyright (c) 2011, Willem-Hendrik Thiart
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of its contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL WILLEM-HENDRIK THIART BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <strings.h>
+#include <string.h>
+#include <assert.h>
+
+#include "linked_list_queue.h"
+
+void *llqueue_new()
+{
+    linked_list_queue_t *qu;
+
+    qu = calloc(1, sizeof(linked_list_queue_t));
+    return qu;
+}
+
+void llqueue_free(
+    linked_list_queue_t * qu
+)
+{
+    llqnode_t *node;
+
+    node = qu->head;
+
+    while (node)
+    {
+        llqnode_t *prev;
+
+        prev = node;
+        node = node->next;
+        free(prev);
+    }
+    free(qu);
+}
+
+void *llqueue_poll(
+    linked_list_queue_t * qu
+)
+{
+    llqnode_t *node;
+
+    void *item;
+
+    if (qu->head == NULL)
+        return NULL;
+
+    node = qu->head;
+    item = node->item;
+    if (qu->tail == qu->head)
+        qu->tail = NULL;
+    qu->head = node->next;
+    free(node);
+    qu->count--;
+
+    return item;
+}
+
+void llqueue_offer(
+    linked_list_queue_t * qu,
+    void *item
+)
+{
+    llqnode_t *node;
+
+    node = malloc(sizeof(llqnode_t));
+    node->item = item;
+    node->next = NULL;
+    if (qu->tail)
+        qu->tail->next = node;
+    if (!qu->head)
+        qu->head = node;
+    qu->tail = node;
+    qu->count++;
+}
+
+void *llqueue_remove_item(
+    linked_list_queue_t * qu,
+    const void *item
+)
+{
+    llqnode_t *node, *prev;
+
+    prev = NULL;
+    node = qu->head;
+
+    while (node)
+    {
+        void *ritem;
+
+        if (node->item == item)
+        {
+            if (node == qu->head)
+            {
+                return llqueue_poll(qu);
+            }
+            else
+            {
+                prev->next = node->next;
+                if (node == qu->tail)
+                {
+                    qu->tail = prev;
+                }
+
+                qu->count--;
+                ritem = node->item;
+                free(node);
+                return ritem;
+            }
+        }
+
+        prev = node;
+        node = node->next;
+    }
+
+    return NULL;
+}
+
+void *llqueue_remove_item_via_cmpfunction(
+    linked_list_queue_t * qu,
+    const void *item,
+    int (*cmp)(const void*, const void*)
+)
+{
+    llqnode_t *node, *prev;
+
+    assert(cmp);
+    assert(item);
+
+    prev = NULL;
+    node = qu->head;
+
+    while (node)
+    {
+        void *ritem;
+
+        if (0 == cmp(node->item,item))
+        {
+            if (node == qu->head)
+            {
+                return llqueue_poll(qu);
+            }
+            else
+            {
+                prev->next = node->next;
+                if (node == qu->tail)
+                {
+                    qu->tail = prev;
+                }
+
+                qu->count--;
+                ritem = node->item;
+                free(node);
+                return ritem;
+            }
+        }
+
+        prev = node;
+        node = node->next;
+    }
+
+    return NULL;
+}
+
+void *llqueue_get_item_via_cmpfunction(
+    linked_list_queue_t * qu,
+    const void *item,
+    long (*cmp)(const void*, const void*)
+)
+{
+    llqnode_t *node;
+
+    assert(cmp);
+    assert(item);
+
+    node = qu->head;
+
+    while (node)
+    {
+        if (0 == cmp(node->item,item))
+        {
+            return node->item;
+        }
+
+        node = node->next;
+    }
+
+    return NULL;
+}
+
+int llqueue_count(
+    const linked_list_queue_t * qu
+)
+{
+    return qu->count;
+}

--- a/contrib/CLinkedListQueue/linked_list_queue.h
+++ b/contrib/CLinkedListQueue/linked_list_queue.h
@@ -1,0 +1,59 @@
+#ifndef LINKED_LIST_QUEUE_H
+#define LINKED_LIST_QUEUE_H
+
+typedef struct llqnode_s llqnode_t;
+
+struct llqnode_s
+{
+    llqnode_t *next;
+    void *item;
+};
+
+typedef struct
+{
+    llqnode_t *head, *tail;
+    int count;
+} linked_list_queue_t;
+
+void *llqueue_new(
+);
+
+void llqueue_free(
+    linked_list_queue_t * qu
+);
+
+void *llqueue_poll(
+    linked_list_queue_t * qu
+);
+
+void llqueue_offer(
+    linked_list_queue_t * qu,
+    void *item
+);
+
+/**
+ * remove this item, by comparing the memory address of the item */
+void *llqueue_remove_item(
+    linked_list_queue_t * qu,
+    const void *item
+);
+
+int llqueue_count(
+    const linked_list_queue_t * qu
+);
+
+/**
+ * remove this item, by using the supplied compare function */
+void *llqueue_remove_item_via_cmpfunction(
+    linked_list_queue_t * qu,
+    const void *item,
+    int (*cmp)(const void*, const void*));
+
+/**
+ * get this item, by using the supplied compare function */
+void *llqueue_get_item_via_cmpfunction(
+    linked_list_queue_t * qu,
+    const void *item,
+    long (*cmp)(const void*, const void*));
+
+#endif /* LINKED_LIST_QUEUE_H */

--- a/contrib/CLinkedListQueue/package.json
+++ b/contrib/CLinkedListQueue/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "linked-list-queue",
+  "version": "0.0.1",
+  "repo": "willemt/linked-list-queue",
+  "description": "A queue using a linked list",
+  "keywords": ["queue"],
+  "license": "BSD",
+  "src": ["linked_list_queue.c", "linked_list_queue.h"]
+}

--- a/contrib/CLinkedListQueue/tests/CuTest.c
+++ b/contrib/CLinkedListQueue/tests/CuTest.c
@@ -1,0 +1,311 @@
+#include <assert.h>
+#include <setjmp.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+#include "CuTest.h"
+
+/*-------------------------------------------------------------------------*
+ * CuStr
+ *-------------------------------------------------------------------------*/
+
+char* CuStrAlloc(int size)
+{
+	char* newStr = (char*) malloc( sizeof(char) * (size) );
+	return newStr;
+}
+
+char* CuStrCopy(const char* old)
+{
+	int len = strlen(old);
+	char* newStr = CuStrAlloc(len + 1);
+	strcpy(newStr, old);
+	return newStr;
+}
+
+/*-------------------------------------------------------------------------*
+ * CuString
+ *-------------------------------------------------------------------------*/
+
+void CuStringInit(CuString* str)
+{
+	str->length = 0;
+	str->size = STRING_MAX;
+	str->buffer = (char*) malloc(sizeof(char) * str->size);
+	str->buffer[0] = '\0';
+}
+
+CuString* CuStringNew(void)
+{
+	CuString* str = (CuString*) malloc(sizeof(CuString));
+	str->length = 0;
+	str->size = STRING_MAX;
+	str->buffer = (char*) malloc(sizeof(char) * str->size);
+	str->buffer[0] = '\0';
+	return str;
+}
+
+void CuStringResize(CuString* str, int newSize)
+{
+	str->buffer = (char*) realloc(str->buffer, sizeof(char) * newSize);
+	str->size = newSize;
+}
+
+void CuStringAppend(CuString* str, const char* text)
+{
+	int length;
+
+	if (text == NULL) {
+		text = "NULL";
+	}
+
+	length = strlen(text);
+	if (str->length + length + 1 >= str->size)
+		CuStringResize(str, str->length + length + 1 + STRING_INC);
+	str->length += length;
+	strcat(str->buffer, text);
+}
+
+void CuStringAppendChar(CuString* str, char ch)
+{
+	char text[2];
+	text[0] = ch;
+	text[1] = '\0';
+	CuStringAppend(str, text);
+}
+
+void CuStringAppendFormat(CuString* str, const char* format, ...)
+{
+	va_list argp;
+	char buf[HUGE_STRING_LEN];
+	va_start(argp, format);
+	vsprintf(buf, format, argp);
+	va_end(argp);
+	CuStringAppend(str, buf);
+}
+
+void CuStringInsert(CuString* str, const char* text, int pos)
+{
+	int length = strlen(text);
+	if (pos > str->length)
+		pos = str->length;
+	if (str->length + length + 1 >= str->size)
+		CuStringResize(str, str->length + length + 1 + STRING_INC);
+	memmove(str->buffer + pos + length, str->buffer + pos, (str->length - pos) + 1);
+	str->length += length;
+	memcpy(str->buffer + pos, text, length);
+}
+
+/*-------------------------------------------------------------------------*
+ * CuTest
+ *-------------------------------------------------------------------------*/
+
+void CuTestInit(CuTest* t, const char* name, TestFunction function)
+{
+	t->name = CuStrCopy(name);
+	t->failed = 0;
+	t->ran = 0;
+	t->message = NULL;
+	t->function = function;
+	t->jumpBuf = NULL;
+}
+
+CuTest* CuTestNew(const char* name, TestFunction function)
+{
+	CuTest* tc = CU_ALLOC(CuTest);
+	CuTestInit(tc, name, function);
+	return tc;
+}
+
+void CuTestRun(CuTest* tc)
+{
+    printf(" running %s\n", tc->name);
+
+	jmp_buf buf;
+	tc->jumpBuf = &buf;
+	if (setjmp(buf) == 0)
+	{
+		tc->ran = 1;
+		(tc->function)(tc);
+	}
+	tc->jumpBuf = 0;
+}
+
+static void CuFailInternal(CuTest* tc, const char* file, int line, CuString* string)
+{
+	char buf[HUGE_STRING_LEN];
+
+	sprintf(buf, "%s:%d: ", file, line);
+	CuStringInsert(string, buf, 0);
+
+	tc->failed = 1;
+	tc->message = string->buffer;
+	if (tc->jumpBuf != 0) longjmp(*(tc->jumpBuf), 0);
+}
+
+void CuFail_Line(CuTest* tc, const char* file, int line, const char* message2, const char* message)
+{
+	CuString string;
+
+	CuStringInit(&string);
+	if (message2 != NULL) 
+	{
+		CuStringAppend(&string, message2);
+		CuStringAppend(&string, ": ");
+	}
+	CuStringAppend(&string, message);
+	CuFailInternal(tc, file, line, &string);
+}
+
+void CuAssert_Line(CuTest* tc, const char* file, int line, const char* message, int condition)
+{
+	if (condition) return;
+	CuFail_Line(tc, file, line, NULL, message);
+}
+
+void CuAssertStrEquals_LineMsg(CuTest* tc, const char* file, int line, const char* message, 
+	const char* expected, const char* actual)
+{
+	CuString string;
+	if ((expected == NULL && actual == NULL) ||
+	    (expected != NULL && actual != NULL &&
+	     strcmp(expected, actual) == 0))
+	{
+		return;
+	}
+
+	CuStringInit(&string);
+	if (message != NULL) 
+	{
+		CuStringAppend(&string, message);
+		CuStringAppend(&string, ": ");
+	}
+	CuStringAppend(&string, "expected <");
+	CuStringAppend(&string, expected);
+	CuStringAppend(&string, "> but was <");
+	CuStringAppend(&string, actual);
+	CuStringAppend(&string, ">");
+	CuFailInternal(tc, file, line, &string);
+}
+
+void CuAssertIntEquals_LineMsg(CuTest* tc, const char* file, int line, const char* message, 
+	int expected, int actual)
+{
+	char buf[STRING_MAX];
+	if (expected == actual) return;
+	sprintf(buf, "expected <%d> but was <%d>", expected, actual);
+	CuFail_Line(tc, file, line, message, buf);
+}
+
+void CuAssertDblEquals_LineMsg(CuTest* tc, const char* file, int line, const char* message, 
+	double expected, double actual, double delta)
+{
+	char buf[STRING_MAX];
+	if (fabs(expected - actual) <= delta) return;
+	sprintf(buf, "expected <%lf> but was <%lf>", expected, actual);
+	CuFail_Line(tc, file, line, message, buf);
+}
+
+void CuAssertPtrEquals_LineMsg(CuTest* tc, const char* file, int line, const char* message, 
+	void* expected, void* actual)
+{
+	char buf[STRING_MAX];
+	if (expected == actual) return;
+	sprintf(buf, "expected pointer <0x%p> but was <0x%p>", expected, actual);
+	CuFail_Line(tc, file, line, message, buf);
+}
+
+
+/*-------------------------------------------------------------------------*
+ * CuSuite
+ *-------------------------------------------------------------------------*/
+
+void CuSuiteInit(CuSuite* testSuite)
+{
+	testSuite->count = 0;
+	testSuite->failCount = 0;
+}
+
+CuSuite* CuSuiteNew(void)
+{
+	CuSuite* testSuite = CU_ALLOC(CuSuite);
+	CuSuiteInit(testSuite);
+	return testSuite;
+}
+
+void CuSuiteAdd(CuSuite* testSuite, CuTest *testCase)
+{
+	assert(testSuite->count < MAX_TEST_CASES);
+	testSuite->list[testSuite->count] = testCase;
+	testSuite->count++;
+}
+
+void CuSuiteAddSuite(CuSuite* testSuite, CuSuite* testSuite2)
+{
+	int i;
+	for (i = 0 ; i < testSuite2->count ; ++i)
+	{
+		CuTest* testCase = testSuite2->list[i];
+		CuSuiteAdd(testSuite, testCase);
+	}
+}
+
+void CuSuiteRun(CuSuite* testSuite)
+{
+	int i;
+	for (i = 0 ; i < testSuite->count ; ++i)
+	{
+		CuTest* testCase = testSuite->list[i];
+		CuTestRun(testCase);
+		if (testCase->failed) { testSuite->failCount += 1; }
+	}
+}
+
+void CuSuiteSummary(CuSuite* testSuite, CuString* summary)
+{
+	int i;
+	for (i = 0 ; i < testSuite->count ; ++i)
+	{
+		CuTest* testCase = testSuite->list[i];
+		CuStringAppend(summary, testCase->failed ? "F" : ".");
+	}
+	CuStringAppend(summary, "\n\n");
+}
+
+void CuSuiteDetails(CuSuite* testSuite, CuString* details)
+{
+	int i;
+	int failCount = 0;
+
+	if (testSuite->failCount == 0)
+	{
+		int passCount = testSuite->count - testSuite->failCount;
+		const char* testWord = passCount == 1 ? "test" : "tests";
+		CuStringAppendFormat(details, "OK (%d %s)\n", passCount, testWord);
+	}
+	else
+	{
+		if (testSuite->failCount == 1)
+			CuStringAppend(details, "There was 1 failure:\n");
+		else
+			CuStringAppendFormat(details, "There were %d failures:\n", testSuite->failCount);
+
+		for (i = 0 ; i < testSuite->count ; ++i)
+		{
+			CuTest* testCase = testSuite->list[i];
+			if (testCase->failed)
+			{
+				failCount++;
+				CuStringAppendFormat(details, "%d) %s: %s\n",
+					failCount, testCase->name, testCase->message);
+			}
+		}
+		CuStringAppend(details, "\n!!!FAILURES!!!\n");
+
+		CuStringAppendFormat(details, "Runs: %d ",   testSuite->count);
+		CuStringAppendFormat(details, "Passes: %d ", testSuite->count - testSuite->failCount);
+		CuStringAppendFormat(details, "Fails: %d\n",  testSuite->failCount);
+	}
+}

--- a/contrib/CLinkedListQueue/tests/CuTest.h
+++ b/contrib/CLinkedListQueue/tests/CuTest.h
@@ -1,0 +1,111 @@
+#ifndef CU_TEST_H
+#define CU_TEST_H
+
+#include <setjmp.h>
+#include <stdarg.h>
+
+/* CuString */
+
+char* CuStrAlloc(int size);
+char* CuStrCopy(const char* old);
+
+#define CU_ALLOC(TYPE)		((TYPE*) malloc(sizeof(TYPE)))
+
+#define HUGE_STRING_LEN	8192
+#define STRING_MAX		256
+#define STRING_INC		256
+
+typedef struct
+{
+	int length;
+	int size;
+	char* buffer;
+} CuString;
+
+void CuStringInit(CuString* str);
+CuString* CuStringNew(void);
+void CuStringRead(CuString* str, const char* path);
+void CuStringAppend(CuString* str, const char* text);
+void CuStringAppendChar(CuString* str, char ch);
+void CuStringAppendFormat(CuString* str, const char* format, ...);
+void CuStringInsert(CuString* str, const char* text, int pos);
+void CuStringResize(CuString* str, int newSize);
+
+/* CuTest */
+
+typedef struct CuTest CuTest;
+
+typedef void (*TestFunction)(CuTest *);
+
+struct CuTest
+{
+	const char* name;
+	TestFunction function;
+	int failed;
+	int ran;
+	const char* message;
+	jmp_buf *jumpBuf;
+};
+
+void CuTestInit(CuTest* t, const char* name, TestFunction function);
+CuTest* CuTestNew(const char* name, TestFunction function);
+void CuTestRun(CuTest* tc);
+
+/* Internal versions of assert functions -- use the public versions */
+void CuFail_Line(CuTest* tc, const char* file, int line, const char* message2, const char* message);
+void CuAssert_Line(CuTest* tc, const char* file, int line, const char* message, int condition);
+void CuAssertStrEquals_LineMsg(CuTest* tc, 
+	const char* file, int line, const char* message, 
+	const char* expected, const char* actual);
+void CuAssertIntEquals_LineMsg(CuTest* tc, 
+	const char* file, int line, const char* message, 
+	int expected, int actual);
+void CuAssertDblEquals_LineMsg(CuTest* tc, 
+	const char* file, int line, const char* message, 
+	double expected, double actual, double delta);
+void CuAssertPtrEquals_LineMsg(CuTest* tc, 
+	const char* file, int line, const char* message, 
+	void* expected, void* actual);
+
+/* public assert functions */
+
+#define CuFail(tc, ms)                        CuFail_Line(  (tc), __FILE__, __LINE__, NULL, (ms))
+#define CuAssert(tc, ms, cond)                CuAssert_Line((tc), __FILE__, __LINE__, (ms), (cond))
+#define CuAssertTrue(tc, cond)                CuAssert_Line((tc), __FILE__, __LINE__, "assert failed", (cond))
+
+#define CuAssertStrEquals(tc,ex,ac)           CuAssertStrEquals_LineMsg((tc),__FILE__,__LINE__,NULL,(ex),(ac))
+#define CuAssertStrEquals_Msg(tc,ms,ex,ac)    CuAssertStrEquals_LineMsg((tc),__FILE__,__LINE__,(ms),(ex),(ac))
+#define CuAssertIntEquals(tc,ex,ac)           CuAssertIntEquals_LineMsg((tc),__FILE__,__LINE__,NULL,(ex),(ac))
+#define CuAssertIntEquals_Msg(tc,ms,ex,ac)    CuAssertIntEquals_LineMsg((tc),__FILE__,__LINE__,(ms),(ex),(ac))
+#define CuAssertDblEquals(tc,ex,ac,dl)        CuAssertDblEquals_LineMsg((tc),__FILE__,__LINE__,NULL,(ex),(ac),(dl))
+#define CuAssertDblEquals_Msg(tc,ms,ex,ac,dl) CuAssertDblEquals_LineMsg((tc),__FILE__,__LINE__,(ms),(ex),(ac),(dl))
+#define CuAssertPtrEquals(tc,ex,ac)           CuAssertPtrEquals_LineMsg((tc),__FILE__,__LINE__,NULL,(ex),(ac))
+#define CuAssertPtrEquals_Msg(tc,ms,ex,ac)    CuAssertPtrEquals_LineMsg((tc),__FILE__,__LINE__,(ms),(ex),(ac))
+
+#define CuAssertPtrNotNull(tc,p)        CuAssert_Line((tc),__FILE__,__LINE__,"null pointer unexpected",(p != NULL))
+#define CuAssertPtrNotNullMsg(tc,msg,p) CuAssert_Line((tc),__FILE__,__LINE__,(msg),(p != NULL))
+
+/* CuSuite */
+
+#define MAX_TEST_CASES	1024
+
+#define SUITE_ADD_TEST(SUITE,TEST)	CuSuiteAdd(SUITE, CuTestNew(#TEST, TEST))
+
+typedef struct
+{
+	int count;
+	CuTest* list[MAX_TEST_CASES];
+	int failCount;
+
+} CuSuite;
+
+
+void CuSuiteInit(CuSuite* testSuite);
+CuSuite* CuSuiteNew(void);
+void CuSuiteAdd(CuSuite* testSuite, CuTest *testCase);
+void CuSuiteAddSuite(CuSuite* testSuite, CuSuite* testSuite2);
+void CuSuiteRun(CuSuite* testSuite);
+void CuSuiteSummary(CuSuite* testSuite, CuString* summary);
+void CuSuiteDetails(CuSuite* testSuite, CuString* details);
+
+#endif /* CU_TEST_H */

--- a/contrib/CLinkedListQueue/tests/make-tests.sh
+++ b/contrib/CLinkedListQueue/tests/make-tests.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Auto generate single AllTests file for CuTest.
+# Searches through all *.c files in the current directory.
+# Prints to stdout.
+# Author: Asim Jalis
+# Date: 01/08/2003
+
+FILES=$1
+
+#if test $# -eq 0 ; then FILES=*.c ; else FILES=$* ; fi
+
+echo '
+
+/* This is auto-generated code. Edit at your own peril. */
+#include <stdio.h>
+#include "CuTest.h"
+
+'
+
+cat $FILES | grep '^void Test' | 
+    sed -e 's/(.*$//' \
+        -e 's/$/(CuTest*);/' \
+        -e 's/^/extern /'
+
+echo \
+'
+
+void RunAllTests(void) 
+{
+    CuString *output = CuStringNew();
+    CuSuite* suite = CuSuiteNew();
+
+'
+cat $FILES | grep '^void Test' | 
+    sed -e 's/^void //' \
+        -e 's/(.*$//' \
+        -e 's/^/    SUITE_ADD_TEST(suite, /' \
+        -e 's/$/);/'
+
+echo \
+'
+    CuSuiteRun(suite);
+    CuSuiteSummary(suite, output);
+    CuSuiteDetails(suite, output);
+    printf("%s\\n", output->buffer);
+}
+
+int main()
+{
+    RunAllTests();
+    return 0;
+}
+'

--- a/contrib/CLinkedListQueue/tests/test_linked_list_queue.c
+++ b/contrib/CLinkedListQueue/tests/test_linked_list_queue.c
@@ -1,0 +1,119 @@
+
+#include <stdbool.h>
+#include <assert.h>
+#include <setjmp.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "CuTest.h"
+
+#include "linked_list_queue.h"
+
+void TestLLQueue_offer(
+    CuTest * tc
+)
+{
+    void *qu;
+
+    char *item = "testitem";
+
+    qu = llqueue_new();
+
+    llqueue_offer(qu, item);
+    CuAssertTrue(tc, 1 == llqueue_count(qu));
+    llqueue_free(qu);
+}
+
+void TestLLQueue_cant_poll_with_no_contents(
+    CuTest * tc
+)
+{
+    void *qu;
+
+    char *item = "testitem";
+
+    qu = llqueue_new();
+    llqueue_offer(qu, item);
+    CuAssertTrue(tc, item == llqueue_poll(qu));
+    CuAssertTrue(tc, 0 == llqueue_count(qu));
+    llqueue_free(qu);
+}
+
+void TestLLQueue_offer_and_poll_item(
+    CuTest * tc
+)
+{
+    void *qu;
+
+    char *item = "testitem";
+
+    qu = llqueue_new();
+
+    llqueue_offer(qu, item);
+    CuAssertTrue(tc, item == llqueue_poll(qu));
+    llqueue_free(qu);
+}
+
+void TestLLQueue_fifo(
+    CuTest * tc
+)
+{
+    void *qu;
+
+    char *item = "testitem", *item2 = "testitem2";
+
+    qu = llqueue_new();
+
+    llqueue_offer(qu, item);
+    llqueue_offer(qu, item2);
+    CuAssertTrue(tc, item == llqueue_poll(qu));
+    CuAssertTrue(tc, item2 == llqueue_poll(qu));
+    llqueue_free(qu);
+}
+
+void TestLLQueue_remove_item_is_null_when_not_available(
+    CuTest * tc
+)
+{
+    void *qu;
+
+    char *item = "testitem", *item2 = "testitem2";
+
+    qu = llqueue_new();
+
+    llqueue_offer(qu, item);
+    CuAssertTrue(tc, NULL == llqueue_remove_item(qu, item2));
+    llqueue_free(qu);
+}
+
+void TestLLQueue_remove_item(
+    CuTest * tc
+)
+{
+    void *qu;
+
+    char *item = "testitem", *item2 = "testitem2";
+
+    qu = llqueue_new();
+
+    llqueue_offer(qu, item);
+    llqueue_offer(qu, item2);
+    CuAssertTrue(tc, item2 == llqueue_remove_item(qu, item2));
+    llqueue_free(qu);
+}
+
+void TestLLQueue_remove_item_when_it_is_head(
+    CuTest * tc
+)
+{
+    void *qu;
+
+    char *item = "testitem", *item2 = "testitem2";
+
+    qu = llqueue_new();
+
+    llqueue_offer(qu, item);
+    llqueue_offer(qu, item2);
+    CuAssertTrue(tc, item == llqueue_remove_item(qu, item));
+    llqueue_free(qu);
+}


### PR DESCRIPTION
CLinkedListQueue is cloned on demand at build time. This causes a few
inconveniences:

  - If the clone (over the Internet) fails, the CLinkedListQueue
    directory is not deleted. Future builds will not clone again, but at
    the same time can not find CLinkedListQueue/linked_list_queue.c.
    (The issue alone could be fixed by changing Makefile.)

  - If the raft source is taken into a build environment without
    Internet access, the clone will fail. This has happened at least
    once in the field.

Since CLinkedListQueue is only used by the tests, and is unlikely to
require frequent updates, this patch adds its source into raft.git.

Signed-off-by: Li Wei <wei.g.li@intel.com>