### PR TITLE
DAOS-2054 server: Always go through elections

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+raft (0.9.0-1) unstable; urgency=medium
+
+  [ Li Wei ]
+  * Remove the upstream optimization that allows election-less leaders
+  * Update packaging
+
+ -- Li Wei <wei.g.li@intel.com>  Wed, Jan 05 2022 14:51:00 +0800
+
 raft (0.8.1-1) unstable; urgency=medium
 
   [ Li Wei ]

--- a/include/raft.h
+++ b/include/raft.h
@@ -896,7 +896,7 @@ void raft_become_leader(raft_server_t* me);
  * currentTerm. */
 void raft_become_follower(raft_server_t* me);
 
-void raft_election_start(raft_server_t* me);
+int raft_election_start(raft_server_t* me);
 
 /** Determine if entry is voting configuration change.
  * @param[in] ety The entry to query.

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -82,7 +82,7 @@ typedef struct {
     raft_term_t snapshot_last_term;
 } raft_server_private_t;
 
-void raft_become_candidate(raft_server_t* me);
+int raft_become_candidate(raft_server_t* me);
 int raft_become_prevoted_candidate(raft_server_t* me_);
 int raft_is_prevoted_candidate(raft_server_t* me_);
 
@@ -144,6 +144,8 @@ int raft_node_has_vote_for_me(raft_node_t* me_);
 void raft_node_set_has_sufficient_logs(raft_node_t* me_);
 
 int raft_votes_is_majority(const int nnodes, const int nvotes);
+
+int raft_count_votes(raft_server_t* me_);
 
 void raft_offer_log(raft_server_t* me_, raft_entry_t* entries,
                     int n_entries, raft_index_t idx);

--- a/packaging/Dockerfile.mockbuild
+++ b/packaging/Dockerfile.mockbuild
@@ -6,7 +6,7 @@
 
 # Pull base image
 FROM fedora:latest
-MAINTAINER daos-stack <daos@daos.groups.io>
+LABEL maintainer="daos@daos.groups.io>"
 
 # use same UID as host and default value of 1000 if not specified
 ARG UID=1000
@@ -28,3 +28,6 @@ RUN usermod -a -G mock $USER
 RUN grep use_nspawn /etc/mock/site-defaults.cfg || \
     echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
 
+ARG CACHEBUST
+RUN dnf -y upgrade && \
+    dnf clean all

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -2,17 +2,4 @@ NAME    := libfabric
 SRC_EXT := gz
 SOURCE   = https://github.com/ofiwg/$(NAME)/archive/v$(VERSION).tar.$(SRC_EXT)
 
-OSUSE_HPC_REPO := https://download.opensuse.org/repositories/science:/HPC
-LEAP_42_HPC_REPO := $(OSUSE_HPC_REPO)/openSUSE_Leap_42.3/
-
-ifeq ($(DAOS_STACK_LEAP_42_GROUP_REPO),)
-LEAP_42_REPOS  := $(LEAP_42_HPC_REPO)
-endif
-ifeq ($(DAOS_STACK_SLES_12_GROUP_REPO),)
-SLES_12_REPOS := $(LEAP_42_HPC_REPO)
-endif
-ifeq ($(DAOS_STACK_LEAP_15_GROUP_REPO),)
-LEAP_15_REPOS := $(OSUSE_HPC_REPO)/openSUSE_Leap_15.1/
-endif
-
 include Makefile_packaging.mk

--- a/packaging/Makefile_distro_vars.mk
+++ b/packaging/Makefile_distro_vars.mk
@@ -27,30 +27,38 @@ SPECTOOL := spectool
 # DISTRO_BASE (i.e. EL_7)
 # from the CHROOT_NAME
 ifeq ($(CHROOT_NAME),epel-7-x86_64)
-DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
-VERSION_ID  := 7
-DISTRO_ID   := el7
-DISTRO_BASE := EL_7
-SED_EXPR    := 1s/$(DIST)//p
+DIST            := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
+VERSION_ID      := 7
+DISTRO_ID       := el7
+DISTRO_BASE     := EL_7
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 7
+SED_EXPR        := 1s/$(DIST)//p
 endif
 ifeq ($(CHROOT_NAME),epel-8-x86_64)
-DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
-VERSION_ID  := 8
-DISTRO_ID   := el8
-DISTRO_BASE := EL_8
-SED_EXPR    := 1s/$(DIST)//p
+DIST            := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
+VERSION_ID      := 8
+DISTRO_ID       := el8
+DISTRO_BASE     := EL_8
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 8
+SED_EXPR        := 1s/$(DIST)//p
 endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.2-x86_64)
-VERSION_ID  := 15.2
-DISTRO_ID   := sl15.2
-DISTRO_BASE := LEAP_15
-SED_EXPR    := 1p
+VERSION_ID      := 15.2
+DISTRO_ID       := sl15.2
+DISTRO_BASE     := LEAP_15
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 15.2
+SED_EXPR        := 1p
 endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.3-x86_64)
-VERSION_ID  := 15.3
-DISTRO_ID   := sl15.3
-DISTRO_BASE := LEAP_15
-SED_EXPR    := 1p
+VERSION_ID      := 15.3
+DISTRO_ID       := sl15.3
+DISTRO_BASE     := LEAP_15
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 15.2
+SED_EXPR        := 1p
 endif
 endif
 ifeq ($(ID),centos)

--- a/packaging/Makefile_packaging.mk
+++ b/packaging/Makefile_packaging.mk
@@ -44,6 +44,17 @@ EL_7_PR_REPOS            ?= $(shell git show -s --format=%B | sed -ne 's/^PR-rep
 EL_8_PR_REPOS            ?= $(shell git show -s --format=%B | sed -ne 's/^PR-repos-el8: *\(.*\)/\1/p')
 UBUNTU_20_04_PR_REPOS    ?= $(shell git show -s --format=%B | sed -ne 's/^PR-repos-ubuntu20: *\(.*\)/\1/p')
 
+ifneq ($(PKG_GIT_COMMIT),)
+ifeq ($(GITHUB_PROJECT),)
+ifeq ($(GIT_PROJECT),)
+$(error You must set either GITHUB_PROJECT or GIT_PROJECT if you set PKG_GIT_COMMIT)
+endif
+endif
+BUILD_DEFINES     := --define "commit $(PKG_GIT_COMMIT)"
+RPM_BUILD_OPTIONS := $(BUILD_DEFINES)
+GIT_DIFF_EXCLUDES := $(PATCH_EXCLUDE_FILES:%=':!%')
+endif
+
 COMMON_RPM_ARGS  := --define "_topdir $$PWD/_topdir" $(BUILD_DEFINES)
 SPEC             := $(shell if [ -f $(NAME)-$(DISTRO_BASE).spec ]; then echo $(NAME)-$(DISTRO_BASE).spec; else echo $(NAME).spec; fi)
 VERSION           = $(eval VERSION := $(shell rpm $(COMMON_RPM_ARGS) --specfile --qf '%{version}\n' $(SPEC) | sed -n '1p'))$(VERSION)
@@ -291,37 +302,80 @@ debs: $(DEBS)
 ls: $(TARGETS)
 	ls -ld $^
 
+ifneq ($(PKG_GIT_COMMIT),)
+# This not really intended to run in CI.  It's meant as a developer
+# convenience to generate the needed patch and add it to the repo to
+# be committed.
+$(VERSION)..$(PKG_GIT_COMMIT).patch:
+ifneq ($(GITHUB_PROJECT),)
+	# it really sucks that GitHub's "compare" returns such dirty patches
+	#curl -O 'https://github.com/$(GITHUB_PROJECT)/compare/$@'
+	git clone https://github.com/$(GITHUB_PROJECT).git
+else
+	git clone $(GIT_PROJECT)
+endif
+	set -x; pushd $(NAME) &&                              \
+	trap 'popd && rm -rf $(NAME)' EXIT;                   \
+	echo git diff $(VERSION)..$(PKG_GIT_COMMIT) --stat -- \
+	    $(GIT_DIFF_EXCLUDES );                            \
+	git diff $(VERSION)..$(PKG_GIT_COMMIT) --             \
+	    $(GIT_DIFF_EXCLUDES) > ../$@;                     \
+	popd;                                                 \
+	trap 'rm -rf $(NAME)' EXIT;                           \
+	git add $@
+patch: $(VERSION)..$(PKG_GIT_COMMIT).patch
+else
+patch:
+	echo "PKG_GIT_COMMIT is not defined"
+endif
+
 # *_LOCAL_* repos are locally built packages.
 # *_GROUP_* repos are a local mirror of a group of upstream repos.
 # *_GROUP_* repos may not supply a repomd.xml.key.
 ifeq ($(LOCAL_REPOS),true)
-ifneq ($(REPOSITORY_URL),)
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO),)
-ifeq ($(ID_LIKE),debian)
-# $(DISTRO_BASE)_LOCAL_REPOS is a list separated by | because you cannot pass lists
-# of values with spaces as environment variables
-$(DISTRO_BASE)_LOCAL_REPOS := [trusted=yes]
-endif
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS) $(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO)/
-endif
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO),)
-DISTRO_REPOS = $(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)/|
-endif
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO),)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO)|
-endif
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO),)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO)|
-endif
-ifneq ($(ID_LIKE),debian)
-ifneq ($(DAOS_STACK_INTEL_ONEAPI_REPO),)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_INTEL_ONEAPI_REPO)|
-endif
-endif
-endif
-endif
+  ifneq ($(REPOSITORY_URL),)
+    # group repos are not working in Nexus so we hack in the group members directly below
+    #ifneq ($(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO),)
+    #DISTRO_REPOS = $(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)
+    #$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)/
+    #endif
+    ifneq ($(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO),)
+      ifeq ($(ID_LIKE),debian)
+        # $(DISTRO_BASE)_LOCAL_REPOS is a list separated by | because you cannot pass lists
+        # of values with spaces as environment variables
+        $(DISTRO_BASE)_LOCAL_REPOS := [trusted=yes]
+      else
+        $(DISTRO_BASE)_LOCAL_REPOS := $(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_LOCAL_REPO)
+        DISTRO_REPOS = disabled # any non-empty value here works and is not used beyond testing if the value is empty or not
+      endif # ifeq ($(ID_LIKE),debian)
+      ifeq ($(DISTRO_BASE), EL_8)
+        # hack to use 8.3 non-group repos on EL_8
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst $(ORIG_TARGET_VER),$(DISTRO_VERSION),$(REPOSITORY_URL)repository/centos-8.3-base-x86_64-proxy|$(REPOSITORY_URL)repository/centos-8.3-extras-x86_64-proxy|$(REPOSITORY_URL)repository/epel-el-8-x86_64-proxy)
+      else ifeq ($(DISTRO_BASE), EL_7)
+        # hack to use 7.9 non-group repos on EL_7
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst $(ORIG_TARGET_VER),$(DISTRO_VERSION),$(REPOSITORY_URL)repository/centos-7.9-base-x86_64-proxy|$(REPOSITORY_URL)repository/centos-7.9-extras-x86_64-proxy|$(REPOSITORY_URL)repository/centos-7.9-updates-x86_64-proxy|$(REPOSITORY_URL)repository/epel-el-7-x86_64-proxy)
+      else ifeq ($(DISTRO_BASE), LEAP_15)
+        # hack to use 15 non-group repos on LEAP_15
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst $(ORIG_TARGET_VER),$(DISTRO_VERSION),$(REPOSITORY_URL)repository/opensuse-15.2-oss-x86_64-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-update-oss-x86_64-provo-mirror-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-update-non-oss-x86_64-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-non-oss-x86_64-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-repo-sle-update-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-repo-backports-update-proxy)
+      else
+        # debian
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS) $(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO)
+      endif # ifeq ($(DISTRO_BASE), *)
+    endif #ifneq ($(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO),)
+    ifneq ($(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO),)
+      $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO)
+    endif
+    # group repos are not working in Nexus so we hack in the group members directly above
+    ifneq ($(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO),)
+      $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO)
+    endif
+    ifneq ($(ID_LIKE),debian)
+      ifneq ($(DAOS_STACK_INTEL_ONEAPI_REPO),)
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_INTEL_ONEAPI_REPO)
+      endif # ifneq ($(DAOS_STACK_INTEL_ONEAPI_REPO),)
+    endif # ifneq ($(ID_LIKE),debian)
+  endif # ifneq ($(REPOSITORY_URL),)
+endif # ifeq ($(LOCAL_REPOS),true)
 ifeq ($(ID_LIKE),debian)
 chrootbuild: $(DEB_TOP)/$(DEB_DSC)
 	$(call distro_map)                                      \

--- a/packaging/rpm_chrootbuild
+++ b/packaging/rpm_chrootbuild
@@ -14,7 +14,7 @@ fi
 : "${WORKSPACE:=$PWD}"
 mock_config_dir="$WORKSPACE/mock"
 original_cfg_file="/etc/mock/${CHROOT_NAME}.cfg"
-cfg_file="$mock_config_dir/${CHROOT_NAME}_daos.cfg"
+cfg_file="$mock_config_dir/${CHROOT_NAME}.cfg"
 mkdir -p "$mock_config_dir"
 ln -sf /etc/mock/templates "$mock_config_dir/"
 ln -sf /etc/mock/logging.ini "$mock_config_dir/"
@@ -57,6 +57,6 @@ done
 echo "\"\"\"" >> "$cfg_file"
 
 # shellcheck disable=SC2086
-eval mock --configdir "$mock_config_dir" -r "${CHROOT_NAME}_daos" \
-     "${repo_dels[*]}" "${repo_adds[*]}" \
+eval mock --configdir "$mock_config_dir" -r "${CHROOT_NAME}" \
+     ${repo_dels[*]} ${repo_adds[*]}                         \
      $MOCK_OPTIONS $RPM_BUILD_OPTIONS "$TARGET"

--- a/raft.spec
+++ b/raft.spec
@@ -9,7 +9,7 @@
 %global debug_package %{nil}
 
 Name:		raft
-Version:	0.8.1
+Version:	0.9.0
 Release:	1%{?relval}%{?dist}
 
 Summary:	C implementation of the Raft Consensus protocol, BSD licensed
@@ -61,6 +61,10 @@ cp -a include/* %{buildroot}/%{_includedir}
 
 
 %changelog
+* Wed Jan 05 2022 Li Wei <wei.g.li@intel.com> -0.9.0-1
+- Remove the upstream optimization that allows election-less leaders
+- Update packaging
+
 * Mon Aug 30 2021 Li Wei <wei.g.li@intel.com> -0.8.1-1
 - Optimize InstallSnapshot performance
 - Update packaging

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -653,8 +653,8 @@ void TestRaft_server_election_timeout_does_promote_us_to_leader_if_there_is_only
     raft_add_node(r, NULL, 1, 1);
     raft_set_election_timeout(r, 1000);
 
-    /* clock over (ie. 1000 + 1), causing new election */
-    raft_periodic(r, 1001);
+    /* clock over (ie. 1000 * 2 + 1), causing new election */
+    raft_periodic(r, 2001);
 
     CuAssertTrue(tc, 1 == raft_is_leader(r));
 }
@@ -672,8 +672,8 @@ void TestRaft_server_election_timeout_does_promote_us_to_leader_if_there_is_only
     raft_add_non_voting_node(r, NULL, 2, 0);
     raft_set_election_timeout(r, 1000);
 
-    /* clock over (ie. 1000 + 1), causing new election */
-    raft_periodic(r, 1001);
+    /* clock over (ie. 2000 + 1), causing new election */
+    raft_periodic(r, 2001);
 
     CuAssertTrue(tc, 1 == raft_is_leader(r));
 }
@@ -2359,6 +2359,7 @@ void TestRaft_candidate_becomes_candidate_is_candidate(CuTest * tc)
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
     raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
 
     raft_become_candidate(r);
     CuAssertTrue(tc, raft_is_candidate(r));
@@ -2375,6 +2376,7 @@ void TestRaft_follower_becoming_candidate_increments_current_term(CuTest * tc)
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
     raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
 
     CuAssertTrue(tc, 0 == raft_get_current_term(r));
     raft_become_candidate(r);

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -2397,6 +2397,7 @@ void TestRaft_follower_becoming_candidate_votes_for_self(CuTest * tc)
     raft_set_callbacks(r, &funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
     CuAssertTrue(tc, -1 == raft_get_voted_for(r));
     raft_become_candidate(r);
     raft_become_prevoted_candidate(r);


### PR DESCRIPTION
An optimization in raft_periodic lets a node who is the only voting node
in its local configuration become a leader without any election. No
persistent term or vote update is involved.

This behavior violates some Raft rules. Consider a two-node
configuration, C = {S1, S2}, where S1 is a follower in term 1 ("F1") and
S2 is a leader in term 1 ("L1"):

    S1 (F1): [C]
    S2 (L1): [C]

Both S1 and S2 have voted for S2 in term 1. Then, S2 is removed,
resulting in a new configuration, D = {S1}. Before S2 receives a reply
from S1 indicating that S1 has D:

    S1 (F1): [C, D]
    S2 (L1): [C, D]

S1 may become a leader in term 1 through the optimization, because it is
the only voting node in D, it doesn't increment the term, and it doesn't
go through any election. Before S2 commits D and steps down, the two
leaders in term 1 may even exist simultaneously.

Another concern is that if S1 above restarts later, it will become the
leader of term 1 again. One may argue that this should be a different
leadership in a different term, for certain volatile states of the user
or raft itself (e.g., nextIndex[] and matchIndex[]) are reset.

After all, the performance benefit from the optimization does not seem
to justify the correctness concerns (or the logical complexity, at
least, if one regards two-node configurations as unimportant). It is
with these considerations, the patch removes the optimization.

Signed-off-by: Li Wei <wei.g.li@intel.com>