### PR TITLE
DAOS-9326 server: Fix membership changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -414,13 +414,13 @@ It's highly recommended that when a node is added to the cluster that its node I
 
 1. Append the configuration change using ``raft_recv_entry``. Make sure the entry has the type set to ``RAFT_LOGTYPE_ADD_NONVOTING_NODE``
 
-2. Once ``node_has_sufficient_logs`` callback fires, append a configuration finalization log entry using ``raft_recv_entry``. Make sure the entry has a type set to ``RAFT_LOGTYPE_ADD_NODE``
+2. Once ``node_has_sufficient_logs`` callback fires, append a configuration finalization log entry using ``raft_recv_entry``. Make sure the entry has a type set to ``RAFT_LOGTYPE_PROMOTE_NODE``
 
 **Removing a node**
 
-1. Append the configuration change using ``raft_recv_entry``. Make sure the entry has the type set to ``RAFT_LOGTYPE_REMOVE_NODE``
+1. Append the configuration change using ``raft_recv_entry``. Make sure the entry has the type set to ``RAFT_LOGTYPE_REMOVE_NODE`` for a voting node or ``RAFT_LOGTYPE_REMOVE_NONVOTING_NODE`` for a non-voting node.
 
-2. Once the ``RAFT_LOGTYPE_REMOVE_NODE`` configuration change log is applied in the ``applylog`` callback we shutdown the server if it is to be removed.
+2. Once the configuration change log is applied in the ``applylog`` callback we shutdown the server if it is to be removed.
 
 **Membership callback**
 
@@ -444,7 +444,6 @@ The process works like this:
 8. Once the peer has the complete snapshot, the user must call ``raft_begin_load_snapshot``.
 9. Peer calls ``raft_add_node`` to add nodes as per the snapshot's membership info.
 10. Peer calls ``raft_node_set_voting`` to nodes as per the snapshot's membership info.
-11. Finally, peer calls ``raft_node_set_active`` to nodes as per the snapshot's membership info.
 
 When a node receives a snapshot it could reuse that snapshot itself for other nodes.
 

--- a/README.rst
+++ b/README.rst
@@ -418,7 +418,7 @@ It's highly recommended that when a node is added to the cluster that its node I
 
 **Removing a node**
 
-1. Append the configuration change using ``raft_recv_entry``. Make sure the entry has the type set to ``RAFT_LOGTYPE_REMOVE_NODE`` for a voting node or ``RAFT_LOGTYPE_REMOVE_NONVOTING_NODE`` for a non-voting node.
+1. Append the configuration change using ``raft_recv_entry``. Make sure the entry has the type set to ``RAFT_LOGTYPE_REMOVE_NODE`` for a voting node or ``RAFT_LOGTYPE_REMOVE_NONVOTING_NODE`` for a non-voting node (e.g., one that was added but not promoted, or one that was demoted with RAFT_LOGTYPE_DEMOTE_NODE).
 
 2. Once the configuration change log is applied in the ``applylog`` callback we shutdown the server if it is to be removed.
 

--- a/README.rst
+++ b/README.rst
@@ -442,8 +442,8 @@ The process works like this:
 6. When the peer receives the chunk, the user must call ``raft_recv_installsnapshot``. When ``recv_installsnapshot`` fires, the user must process the chunk and fill any implementation-specific arguments to the response.
 7. When the ``recv_installsnapshot_response`` callback fires, the user must record the progress of the snapshot transfer, typically in the user data of the ``raft_node_t`` object for the peer.
 8. Once the peer has the complete snapshot, the user must call ``raft_begin_load_snapshot``.
-9. Peer calls ``raft_remove_node`` to remove all nodes.
-10. Peer calls ``raft_add_node`` to add nodes as per the snapshot's membership info.
+9. Peer calls ``raft_add_node`` to add nodes as per the snapshot's membership info.
+10. Peer calls ``raft_node_set_voting`` to nodes as per the snapshot's membership info.
 11. Finally, peer calls ``raft_node_set_active`` to nodes as per the snapshot's membership info.
 
 When a node receives a snapshot it could reuse that snapshot itself for other nodes.

--- a/include/raft.h
+++ b/include/raft.h
@@ -77,7 +77,7 @@ typedef enum {
      * Membership change.
      * Remove a non-voting node.
      */
-    RAFT_LOGTYPE_REMOVE_NON_VOTING_NODE,
+    RAFT_LOGTYPE_REMOVE_NONVOTING_NODE,
     /**
      * Users can piggyback the entry mechanism by specifying log types that
      * are higher than RAFT_LOGTYPE_NUM.

--- a/include/raft.h
+++ b/include/raft.h
@@ -754,10 +754,6 @@ int raft_get_request_timeout(raft_server_t* me);
 raft_index_t raft_get_last_applied_idx(raft_server_t* me);
 
 /**
- * Set index of the last applied entry */
-void raft_set_last_applied_idx(raft_server_t* me_, raft_index_t idx);
-
-/**
  * @return the node's next index */
 raft_index_t raft_node_get_next_idx(raft_node_t* node);
 

--- a/include/raft.h
+++ b/include/raft.h
@@ -20,6 +20,7 @@ typedef enum {
     RAFT_ERR_NEEDS_SNAPSHOT=-6,
     RAFT_ERR_SNAPSHOT_IN_PROGRESS=-7,
     RAFT_ERR_SNAPSHOT_ALREADY_LOADED=-8,
+    RAFT_ERR_INVALID_CFG_CHANGE=-9,
     RAFT_ERR_LAST=-100,
 } raft_error_e;
 
@@ -59,18 +60,24 @@ typedef enum {
     RAFT_LOGTYPE_ADD_NODE,
     /**
      * Membership change.
-     * Nodes become demoted when we want to remove them from the cluster.
-     * Demoted nodes can't take part in voting or start elections.
-     * Demoted nodes become inactive, as per raft_node_is_active.
+     * Demote a voting node to a non-voting node.
      */
     RAFT_LOGTYPE_DEMOTE_NODE,
     /**
      * Membership change.
-     * The node is removed from the cluster.
-     * This happens after the node has been demoted.
-     * Removing nodes is a 2 step process: first demote, then remove.
+     * Remove a voting node.
      */
     RAFT_LOGTYPE_REMOVE_NODE,
+    /**
+     * Membership change.
+     * Promote a non-voting node to a voting node.
+     */
+    RAFT_LOGTYPE_PROMOTE_NODE,
+    /**
+     * Membership change.
+     * Remove a non-voting node.
+     */
+    RAFT_LOGTYPE_REMOVE_NON_VOTING_NODE,
     /**
      * Users can piggyback the entry mechanism by specifying log types that
      * are higher than RAFT_LOGTYPE_NUM.
@@ -496,6 +503,7 @@ typedef struct
 
     /** Callback for determining which node this configuration log entry
      * affects. This call only applies to configuration change log entries.
+     * @note entry_idx may be 0, indicating that the index is unknown.
      * @return the node ID of the node */
     func_logentry_event_f log_get_node_id;
 
@@ -541,11 +549,7 @@ void raft_set_callbacks(raft_server_t* me, raft_cbs_t* funcs, void* user_data);
 
 /** Add node.
  *
- * If a voting node already exists the call will fail.
- *
- * @note The order this call is made is important.
- *  This call MUST be made in the same order as the other raft nodes.
- *  This is because the node ID is assigned depending on when this call is made
+ * If a node with the same ID already exists the call will fail.
  *
  * @param[in] user_data The user data for the node.
  *  This is obtained using raft_node_get_udata.
@@ -975,30 +979,5 @@ raft_index_t raft_get_snapshot_last_idx(raft_server_t *me_);
 raft_term_t raft_get_snapshot_last_term(raft_server_t *me_);
 
 void raft_set_snapshot_metadata(raft_server_t *me_, raft_term_t term, raft_index_t idx);
-
-/** Check if a node is active.
- * Active nodes could become voting nodes.
- * This should be used for creating the membership snapshot.
- **/
-int raft_node_is_active(raft_node_t* me_);
-
-/** Make the node active.
- *
- * The user sets this to 1 between raft_begin_load_snapshot and
- * raft_end_load_snapshot.
- *
- * @param[in] active Set a node as active if this is 1
- **/
-void raft_node_set_active(raft_node_t* me_, int active);
-
-/** Check if a node's voting status has been committed.
- * This should be used for creating the membership snapshot.
- **/
-int raft_node_is_voting_committed(raft_node_t* me_);
-
-/** Check if a node's membership to the cluster has been committed.
- * This should be used for creating the membership snapshot.
- **/
-int raft_node_is_addition_committed(raft_node_t* me_);
 
 #endif /* RAFT_H_ */

--- a/include/raft_log.h
+++ b/include/raft_log.h
@@ -56,4 +56,6 @@ raft_index_t log_get_base(log_t* me_);
 
 raft_term_t log_get_base_term(log_t* me_);
 
+raft_index_t log_size(log_t* me_);
+
 #endif /* RAFT_LOG_H_ */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -121,21 +121,11 @@ raft_node_t* raft_node_new(void* udata, raft_node_id_t id);
 
 void raft_node_free(raft_node_t* me_);
 
-void raft_node_set_server(raft_node_t* me_, raft_server_t *server);
-
 void raft_node_set_next_idx(raft_node_t* node, raft_index_t nextIdx);
 
 void raft_node_set_match_idx(raft_node_t* node, raft_index_t matchIdx);
 
 raft_index_t raft_node_get_match_idx(raft_node_t* me_);
-
-void raft_node_set_offered_idx(raft_node_t* me_, raft_index_t offeredIdx);
-
-raft_index_t raft_node_get_offered_idx(raft_node_t* me_);
-
-void raft_node_set_applied_idx(raft_node_t* me_, raft_index_t appliedIdx);
-
-raft_index_t raft_node_get_applied_idx(raft_node_t* me_);
 
 void raft_node_vote_for_me(raft_node_t* me_, const int vote);
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -145,12 +145,6 @@ void raft_pop_log(raft_server_t* me_, raft_entry_t* entries,
 
 raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me_);
 
-int raft_node_is_active(raft_node_t* me_);
-
-void raft_node_set_voting_committed(raft_node_t* me_, int voting);
-
-int raft_node_set_addition_committed(raft_node_t* me_, int committed);
-
 int raft_get_entry_term(raft_server_t* me_, raft_index_t idx, raft_term_t* term);
 
 #endif /* RAFT_PRIVATE_H_ */

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -17,19 +17,18 @@
 #include "raft.h"
 
 #define RAFT_NODE_VOTED_FOR_ME        (1 << 0)
-#define RAFT_NODE_HAS_SUFFICIENT_LOG  (1 << 1)
+#define RAFT_NODE_VOTING              (1 << 1)
+#define RAFT_NODE_HAS_SUFFICIENT_LOG  (1 << 2)
+#define RAFT_NODE_INACTIVE            (1 << 3)
+#define RAFT_NODE_VOTING_COMMITTED    (1 << 4)
+#define RAFT_NODE_ADDITION_COMMITTED  (1 << 5)
 
 typedef struct
 {
-    raft_server_t* server;
     void* udata;
 
     raft_index_t next_idx;
     raft_index_t match_idx;
-    /* index of last offered log entry for this node */
-    raft_index_t offered_idx;
-    /* index of last committed log entry for this node */
-    raft_index_t applied_idx;
 
     int flags;
 
@@ -45,22 +44,14 @@ raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
     me->udata = udata;
     me->next_idx = 1;
     me->match_idx = 0;
-    me->offered_idx = -1;
-    me->applied_idx = -2; /* start with addition not committed */
     me->id = id;
-    me->flags = 0;
+    me->flags = RAFT_NODE_VOTING;
     return (raft_node_t*)me;
 }
 
 void raft_node_free(raft_node_t* me_)
 {
     free(me_);
-}
-
-void raft_node_set_server(raft_node_t* me_, raft_server_t *server)
-{
-    raft_node_private_t* me = (raft_node_private_t*)me_;
-    me->server = server;
 }
 
 raft_index_t raft_node_get_next_idx(raft_node_t* me_)
@@ -86,30 +77,6 @@ void raft_node_set_match_idx(raft_node_t* me_, raft_index_t matchIdx)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     me->match_idx = matchIdx;
-}
-
-raft_index_t raft_node_get_offered_idx(raft_node_t* me_)
-{
-    raft_node_private_t* me = (raft_node_private_t*)me_;
-    return me->offered_idx;
-}
-
-void raft_node_set_offered_idx(raft_node_t* me_, raft_index_t offeredIdx)
-{
-    raft_node_private_t* me = (raft_node_private_t*)me_;
-    me->offered_idx = offeredIdx;
-}
-
-raft_index_t raft_node_get_applied_idx(raft_node_t* me_)
-{
-    raft_node_private_t* me = (raft_node_private_t*)me_;
-    return me->applied_idx;
-}
-
-void raft_node_set_applied_idx(raft_node_t* me_, raft_index_t appliedIdx)
-{
-    raft_node_private_t* me = (raft_node_private_t*)me_;
-    me->applied_idx = appliedIdx;
 }
 
 void* raft_node_get_udata(raft_node_t* me_)
@@ -139,6 +106,27 @@ int raft_node_has_vote_for_me(raft_node_t* me_)
     return (me->flags & RAFT_NODE_VOTED_FOR_ME) != 0;
 }
 
+void raft_node_set_voting(raft_node_t* me_, int voting)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    if (voting)
+    {
+        assert(!raft_node_is_voting(me_));
+        me->flags |= RAFT_NODE_VOTING;
+    }
+    else
+    {
+        assert(raft_node_is_voting(me_));
+        me->flags &= ~RAFT_NODE_VOTING;
+    }
+}
+
+int raft_node_is_voting(raft_node_t* me_)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    return (me->flags & RAFT_NODE_VOTING) != 0;
+}
+
 int raft_node_has_sufficient_logs(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
@@ -151,48 +139,53 @@ void raft_node_set_has_sufficient_logs(raft_node_t* me_)
     me->flags |= RAFT_NODE_HAS_SUFFICIENT_LOG;
 }
 
-int raft_node_is_voting(raft_node_t* me_)
+void raft_node_set_active(raft_node_t* me_, int active)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
-    if (!me)
-        return 0;
-    if (me->offered_idx == -1)
-        return raft_node_is_voting_committed(me_);
-    raft_entry_t *ety = raft_get_entry_from_idx(me->server, me->offered_idx);
-    return (!ety || ety->type == RAFT_LOGTYPE_ADD_NODE);
+    if (!active)
+        me->flags |= RAFT_NODE_INACTIVE;
+    else
+        me->flags &= ~RAFT_NODE_INACTIVE;
 }
 
 int raft_node_is_active(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
-    if (me->offered_idx == -1)
-        return raft_node_is_addition_committed(me_);
-    raft_entry_t *ety = raft_get_entry_from_idx(me->server, me->offered_idx);
-    /* A node is active by default, unless explicitly marked for removal */
-    return (!ety || ety->type != RAFT_LOGTYPE_REMOVE_NODE);
+    return (me->flags & RAFT_NODE_INACTIVE) == 0;
+}
+
+void raft_node_set_voting_committed(raft_node_t* me_, int voting)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    if (voting)
+        me->flags |= RAFT_NODE_VOTING_COMMITTED;
+    else
+        me->flags &= ~RAFT_NODE_VOTING_COMMITTED;
 }
 
 int raft_node_is_voting_committed(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
-    if (me->applied_idx < 0)
-        return 0;
-    raft_entry_t *ety = raft_get_entry_from_idx(me->server, me->applied_idx);
-    return (!ety || ety->type == RAFT_LOGTYPE_ADD_NODE);
-}
-
-int raft_node_is_addition_committed(raft_node_t* me_)
-{
-    raft_node_private_t* me = (raft_node_private_t*)me_;
-    if (me->applied_idx < -1)
-        return 0;
-    raft_entry_t *ety = raft_get_entry_from_idx(me->server, me->applied_idx);
-    /* Addition is committed if highest applied entry is not for removal */
-    return (!ety || ety->type != RAFT_LOGTYPE_REMOVE_NODE);
+    return (me->flags & RAFT_NODE_VOTING_COMMITTED) != 0;
 }
 
 raft_node_id_t raft_node_get_id(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return (NULL == me) ? -1 : me->id;
+}
+
+void raft_node_set_addition_committed(raft_node_t* me_, int committed)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    if (committed)
+        me->flags |= RAFT_NODE_ADDITION_COMMITTED;
+    else
+        me->flags &= ~RAFT_NODE_ADDITION_COMMITTED;
+}
+
+int raft_node_is_addition_committed(raft_node_t* me_)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    return (me->flags & RAFT_NODE_ADDITION_COMMITTED) != 0;
 }

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -19,9 +19,6 @@
 #define RAFT_NODE_VOTED_FOR_ME        (1 << 0)
 #define RAFT_NODE_VOTING              (1 << 1)
 #define RAFT_NODE_HAS_SUFFICIENT_LOG  (1 << 2)
-#define RAFT_NODE_INACTIVE            (1 << 3)
-#define RAFT_NODE_VOTING_COMMITTED    (1 << 4)
-#define RAFT_NODE_ADDITION_COMMITTED  (1 << 5)
 
 typedef struct
 {
@@ -139,53 +136,8 @@ void raft_node_set_has_sufficient_logs(raft_node_t* me_)
     me->flags |= RAFT_NODE_HAS_SUFFICIENT_LOG;
 }
 
-void raft_node_set_active(raft_node_t* me_, int active)
-{
-    raft_node_private_t* me = (raft_node_private_t*)me_;
-    if (!active)
-        me->flags |= RAFT_NODE_INACTIVE;
-    else
-        me->flags &= ~RAFT_NODE_INACTIVE;
-}
-
-int raft_node_is_active(raft_node_t* me_)
-{
-    raft_node_private_t* me = (raft_node_private_t*)me_;
-    return (me->flags & RAFT_NODE_INACTIVE) == 0;
-}
-
-void raft_node_set_voting_committed(raft_node_t* me_, int voting)
-{
-    raft_node_private_t* me = (raft_node_private_t*)me_;
-    if (voting)
-        me->flags |= RAFT_NODE_VOTING_COMMITTED;
-    else
-        me->flags &= ~RAFT_NODE_VOTING_COMMITTED;
-}
-
-int raft_node_is_voting_committed(raft_node_t* me_)
-{
-    raft_node_private_t* me = (raft_node_private_t*)me_;
-    return (me->flags & RAFT_NODE_VOTING_COMMITTED) != 0;
-}
-
 raft_node_id_t raft_node_get_id(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return (NULL == me) ? -1 : me->id;
-}
-
-void raft_node_set_addition_committed(raft_node_t* me_, int committed)
-{
-    raft_node_private_t* me = (raft_node_private_t*)me_;
-    if (committed)
-        me->flags |= RAFT_NODE_ADDITION_COMMITTED;
-    else
-        me->flags &= ~RAFT_NODE_ADDITION_COMMITTED;
-}
-
-int raft_node_is_addition_committed(raft_node_t* me_)
-{
-    raft_node_private_t* me = (raft_node_private_t*)me_;
-    return (me->flags & RAFT_NODE_ADDITION_COMMITTED) != 0;
 }

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1476,6 +1476,20 @@ int raft_begin_load_snapshot(
     me->last_applied_idx = last_included_index;
     raft_set_snapshot_metadata(me_, last_included_term, me->last_applied_idx);
 
+    /* remove all nodes but self */
+    int i, my_node_by_idx = 0;
+    for (i = 0; i < me->num_nodes; i++)
+    {
+        if (raft_get_nodeid(me_) == raft_node_get_id(me->nodes[i]))
+            my_node_by_idx = i;
+        else
+            raft_node_set_active(me->nodes[i], 0);
+    }
+
+    /* this will be realloc'd by a raft_add_node */
+    me->nodes[0] = me->nodes[my_node_by_idx];
+    me->num_nodes = 1;
+
     __log(me_, NULL,
         "loaded snapshot sli:%ld slt:%ld slogs:%ld\n",
         me->snapshot_last_idx,

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1477,9 +1477,8 @@ int raft_begin_load_snapshot(
     raft_set_snapshot_metadata(me_, last_included_term, me->last_applied_idx);
 
     /* remove all nodes */
-    int i;
-    for (i = 0; i < me->num_nodes; i++)
-        raft_remove_node(me_, me->nodes[i]);
+    while (me->num_nodes > 0)
+        raft_remove_node(me_, me->nodes[0]);
 
     /* this will be realloc'd by a raft_add_node */
     me->num_nodes = 0;

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1476,19 +1476,13 @@ int raft_begin_load_snapshot(
     me->last_applied_idx = last_included_index;
     raft_set_snapshot_metadata(me_, last_included_term, me->last_applied_idx);
 
-    /* remove all nodes but self */
-    int i, my_node_by_idx = 0;
+    /* remove all nodes */
+    int i;
     for (i = 0; i < me->num_nodes; i++)
-    {
-        if (raft_get_nodeid(me_) == raft_node_get_id(me->nodes[i]))
-            my_node_by_idx = i;
-        else
-            raft_node_set_active(me->nodes[i], 0);
-    }
+        raft_remove_node(me_, me->nodes[i]);
 
     /* this will be realloc'd by a raft_add_node */
-    me->nodes[0] = me->nodes[my_node_by_idx];
-    me->num_nodes = 1;
+    me->num_nodes = 0;
 
     __log(me_, NULL,
         "loaded snapshot sli:%ld slt:%ld slogs:%ld\n",

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -259,7 +259,7 @@ void raft_become_follower(raft_server_t* me_)
 int raft_periodic(raft_server_t* me_, int msec_since_last_period)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
-    raft_node_t *my_node = raft_get_my_node((void *)me);
+    raft_node_t *my_node = raft_get_my_node(me_);
 
     me->timeout_elapsed += msec_since_last_period;
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1094,7 +1094,7 @@ raft_node_t* raft_add_node_internal(raft_server_t* me_, raft_entry_t *ety, void*
     /* we shouldn't add a node twice */
     raft_node_t* node = raft_get_node(me_, id);
     if (node)
-            return NULL;
+        return NULL;
 
     node = raft_node_new(udata, id);
     if (!node)

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -862,7 +862,7 @@ static int __cfg_change_is_valid(raft_server_private_t* me, msg_entry_t* ety)
             break;
 
         case RAFT_LOGTYPE_PROMOTE_NODE:
-        case RAFT_LOGTYPE_REMOVE_NON_VOTING_NODE:
+        case RAFT_LOGTYPE_REMOVE_NONVOTING_NODE:
             if (!node || raft_node_is_voting(node))
                 return 0;
             break;
@@ -1259,7 +1259,7 @@ int raft_entry_is_cfg_change(raft_entry_t* ety)
            RAFT_LOGTYPE_ADD_NONVOTING_NODE == ety->type ||
            RAFT_LOGTYPE_PROMOTE_NODE == ety->type ||
            RAFT_LOGTYPE_DEMOTE_NODE == ety->type ||
-           RAFT_LOGTYPE_REMOVE_NON_VOTING_NODE == ety->type ||
+           RAFT_LOGTYPE_REMOVE_NONVOTING_NODE == ety->type ||
            RAFT_LOGTYPE_REMOVE_NODE == ety->type;
 }
 
@@ -1313,7 +1313,7 @@ void raft_offer_log(raft_server_t* me_, raft_entry_t* entries,
                 raft_remove_node(me_, node);
                 break;
 
-            case RAFT_LOGTYPE_REMOVE_NON_VOTING_NODE:
+            case RAFT_LOGTYPE_REMOVE_NONVOTING_NODE:
                 assert(node && !raft_node_is_voting(node));
                 raft_remove_node(me_, node);
                 break;
@@ -1358,7 +1358,7 @@ void raft_pop_log(raft_server_t* me_, raft_entry_t* entries,
                 assert(node);
                 break;
 
-            case RAFT_LOGTYPE_REMOVE_NON_VOTING_NODE:
+            case RAFT_LOGTYPE_REMOVE_NONVOTING_NODE:
                 assert(!node);
                 node = raft_add_non_voting_node_internal(me_, ety, NULL, node_id, is_self);
                 assert(node);

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1337,7 +1337,7 @@ void raft_pop_log(raft_server_t* me_, raft_entry_t* entries,
         if (!raft_entry_is_cfg_change(ety))
             continue;
 
-        if (idx - i <= me->voting_cfg_change_log_idx)
+        if (idx + i <= me->voting_cfg_change_log_idx)
             me->voting_cfg_change_log_idx = -1;
 
         raft_node_id_t node_id = me->cb.log_get_node_id(me_, raft_get_udata(me_),

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -58,7 +58,7 @@ int raft_get_num_voting_nodes(raft_server_t* me_)
     raft_server_private_t* me = (raft_server_private_t*)me_;
     int i, num = 0;
     for (i = 0; i < me->num_nodes; i++)
-        if (raft_node_is_active(me->nodes[i]) && raft_node_is_voting(me->nodes[i]))
+        if (raft_node_is_voting(me->nodes[i]))
             num++;
     return num;
 }

--- a/tests/test_node.c
+++ b/tests/test_node.c
@@ -10,10 +10,10 @@
 #include "raft_log.h"
 #include "raft_private.h"
 
-void TestRaft_is_non_voting_by_default(CuTest * tc)
+void TestRaft_is_voting_by_default(CuTest * tc)
 {
     raft_node_t *p = raft_node_new((void*)1, 1);
-    CuAssertTrue(tc, !raft_node_is_voting(p));
+    CuAssertTrue(tc, raft_node_is_voting(p));
     raft_node_free(p);
 }
 

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -83,14 +83,6 @@ static int __raft_log_offer(raft_server_t* raft,
         raft_index_t entry_idx,
         int *n_entries)
 {
-    int i;
-    for (i = 0; i < *n_entries; ++i)
-    {
-        raft_entry_t *ety = &entries[i];
-
-        if (ety->type == RAFT_LOGTYPE_ADD_NONVOTING_NODE)
-            raft_add_non_voting_node(raft, NULL, atoi(ety->data.buf), false);
-    }
     return 0;
 }
 

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -3332,7 +3332,7 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_for_nod
     raft_add_node(r, NULL, 2, 0);
     raft_add_node(r, NULL, 3, 0);
     raft_add_node(r, NULL, 4, 0);
-    raft_node_t* node = raft_add_non_voting_node(r, NULL, 5, 0);
+    raft_node_t* node = raft_add_node(r, NULL, 5, 0);
 
     int has_sufficient_logs_flag = 0;
     raft_set_callbacks(r, &funcs, &has_sufficient_logs_flag);
@@ -3364,6 +3364,7 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_for_nod
     aer.current_idx = 2;
     aer.first_idx = 1;
 
+    raft_node_set_voting(node, 0);
     raft_recv_appendentries_response(r, node, &aer);
     CuAssertIntEquals(tc, 1, has_sufficient_logs_flag);
 

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -199,17 +199,6 @@ void TestRaft_server_voting_results_in_voting(CuTest * tc)
     CuAssertTrue(tc, 9 == raft_get_voted_for(r));
 }
 
-void TestRaft_server_add_node_makes_non_voting_node_voting(CuTest * tc)
-{
-    void *r = raft_new();
-    void* n1 = raft_add_non_voting_node(r, NULL, 9, 0);
-
-    CuAssertTrue(tc, !raft_node_is_voting(n1));
-    raft_add_node(r, NULL, 9, 0);
-    CuAssertTrue(tc, raft_node_is_voting(n1));
-    CuAssertIntEquals(tc, 1, raft_get_num_nodes(r));
-}
-
 void TestRaft_server_add_node_with_already_existing_id_is_not_allowed(CuTest * tc)
 {
     void *r = raft_new();
@@ -693,7 +682,12 @@ void TestRaft_server_recv_entry_auto_commits_if_we_are_the_only_node(CuTest * tc
 
 void TestRaft_server_recv_entry_fails_if_there_is_already_a_voting_change(CuTest * tc)
 {
+    raft_cbs_t funcs = {
+        .log_get_node_id = __raft_log_get_node_id,
+    };
+
     void *r = raft_new();
+    raft_set_callbacks(r, &funcs, NULL);
     raft_add_node(r, NULL, 1, 1);
     raft_set_election_timeout(r, 1000);
     raft_become_leader(r);
@@ -701,17 +695,24 @@ void TestRaft_server_recv_entry_fails_if_there_is_already_a_voting_change(CuTest
 
     /* entry message */
     msg_entry_t ety = {};
-    ety.type = RAFT_LOGTYPE_ADD_NODE;
+    ety.type = RAFT_LOGTYPE_ADD_NONVOTING_NODE;
     ety.id = 1;
-    ety.data.buf = "entry";
-    ety.data.len = strlen("entry");
+    ety.data.buf = "2";
+    ety.data.len = 2;
 
     /* receive entry */
     msg_entry_response_t cr;
     CuAssertTrue(tc, 0 == raft_recv_entry(r, &ety, &cr));
     CuAssertTrue(tc, 1 == raft_get_log_count(r));
 
+    /* promote */
+    ety.type = RAFT_LOGTYPE_PROMOTE_NODE;
     ety.id = 2;
+    CuAssertTrue(tc, 0 == raft_recv_entry(r, &ety, &cr));
+    CuAssertTrue(tc, 2 == raft_get_log_count(r));
+
+    ety.type = RAFT_LOGTYPE_DEMOTE_NODE;
+    ety.id = 3;
     CuAssertTrue(tc, RAFT_ERR_ONE_VOTING_CHANGE_ONLY == raft_recv_entry(r, &ety, &cr));
     CuAssertTrue(tc, 1 == raft_get_commit_idx(r));
 }
@@ -4417,11 +4418,12 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_after_v
     raft_recv_appendentries_response(r, raft_get_node(r, 3), &aer);
     CuAssertIntEquals(tc, 1, has_sufficient_logs_flag);
 
+    /* promote node 3 */
     ety.id++;
-    ety.type = RAFT_LOGTYPE_ADD_NODE;
-    raft_recv_entry(r, &ety, &etyr);
+    ety.type = RAFT_LOGTYPE_PROMOTE_NODE;
+    CuAssertIntEquals(tc, 0, raft_recv_entry(r, &ety, &etyr));
 
-    /* we now get a response from node 2, but it's still behind */
+    /* we now get a response from node 2, but a voting change is in progress */
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 1, has_sufficient_logs_flag);
 


### PR DESCRIPTION
(The core change here may be of no interest to the upstream.)

Unfortunately, daos ends up needing to support re-adding a node with its
previous ID, which does not work properly with our algorithm and is not
supported by the upstream algorithm too. While daos will avoid reusing
node IDs eventually, it needs to provide compatiblity for existing
persistent raft state. This patch therefore reverts to the upstream
algorithm but drops the troublemaking logic that tracks the last applied
membership, which is not used by daos. The resulting algorithm is based
on the following principles:

  - raft only tracks the active membership; the user shall track the
    last applied membership for snapshotting purposes. (Tracking both
    using the same set of raft_node_t objects in raft proves to be
    complex. The user does get a burden, but a very clear one.)
      * The INACTIVE flag allows a node to be absent in the active
        membership but still present in the last applied one.
      * The ADDITION_COMMITTED and VOTING_COMMITTED flags track the last
        applied membership. The former corresponds to the INACTIVE flag
        for the active membership; the latter to the VOTING flag.

  - Each membership change entry is a clear transition from a fixed
    pre-state to a fixed post-state. For instance, ADD_NODE changes a
    node from absent to voting. This enables clear undo logic in
    raft_pop_log.
      * PROMOTE_NODE and REMOVE_NON_VOTING_NODE are introduced to enable
        upgrading from existing persistent raft state that doesn't use
        non-voting nodes.

This patch also makes the following minor changes:

  - Fix an upstream bug that does not consider REMOVE_NODE as a voting
    configuration change.

  - Add a check to raft_recv_entry for invalid membership change
    entries.
      * Removing a leader is currently not safe and now prohibited.
      * Enforce the pre-state of each membership change.

  - Remove a redundant setting of voting_cfg_change_log_idx in
    raft_clear.

  - Change raft_add_node to disallow "promotion" semantics, which shall
    be unnecessary to the user.

  - Fix an upstream log_delete bug that causes log_get_node_id to
    operate with an entry that has already been popped.

  - Fix a log_delete bug that causes incorrect indices to be passed to
    log_pop.

Signed-off-by: Li Wei <wei.g.li@intel.com>