### PR TITLE
Raft server's nodes vector is not freed when raft_free is invoked

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -93,6 +93,8 @@ void raft_free(raft_server_t* me_)
     raft_server_private_t* me = (raft_server_private_t*)me_;
 
     log_free(me->log);
+    if (me->nodes)
+        free(me->nodes);
     free(me_);
 }
 


### PR DESCRIPTION
This fix is cherry-picked from the upstream.

Signed-off-by: Li Wei <wei.g.li@intel.com>