### PR TITLE
DAOS-10249 server: Fix RV assertion failures

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+raft (0.9.2-1) unstable; urgency=medium
+
+  [ Li Wei ]
+  * Fix assertion failures in raft_recv_requestvote
+
+ -- Li Wei <wei.g.li@intel.com>  Mon, Feb 13 2023 10:14:00 +0800
+
 raft (0.9.1-1) unstable; urgency=medium
 
   [ Li Wei ]

--- a/packaging/Dockerfile.mockbuild
+++ b/packaging/Dockerfile.mockbuild
@@ -34,17 +34,23 @@ RUN echo "$USER:$PASSWD" | chpasswd
 # add the user to the mock group so it can run mock
 RUN usermod -a -G mock $USER
 
-# Monkey-patch rpmlint until a new release is made with
-# https://github.com/rpm-software-management/rpmlint/pull/795 in it
-COPY packaging/rpmlint--ignore-unused-rpmlintrc.patch .
-RUN (cd $(python3 -c 'import site; print(site.getsitepackages()[-1])') &&                    \
-     patch -p1 &&                                                                            \
-     rm -f rpmlint/__pycache__/{cli,lint}.*.pyc) < rpmlint--ignore-unused-rpmlintrc.patch && \
-    rm -f  rpmlint--ignore-unused-rpmlintrc.patch
-
 ARG CB0
 RUN dnf -y upgrade && \
     dnf clean all
+
+# Monkey-patch rpmlint until a new release is made with
+# https://github.com/rpm-software-management/rpmlint/pull/795 in it
+# But make sure to patch after dnf upgrade so that an upgraded rpmlint
+# RPM doesn't wipe out our patch
+COPY packaging/rpmlint--ignore-unused-rpmlintrc.patch .
+RUN (cd $(python3 -c 'import site; print(site.getsitepackages()[-1])') &&                      \
+     if ! grep -e --ignore-unused-rpmlintrc rpmlint/cli.py; then                               \
+         if ! patch -p1; then                                                                  \
+             exit 1;                                                                           \
+         fi;                                                                                   \
+         rm -f rpmlint/__pycache__/{cli,lint}.*.pyc;                                           \
+     fi) < rpmlint--ignore-unused-rpmlintrc.patch;                                             \
+    rm -f  rpmlint--ignore-unused-rpmlintrc.patch
 
 # show the release that was built
 ARG CACHEBUST

--- a/packaging/Dockerfile.ubuntu.20.04
+++ b/packaging/Dockerfile.ubuntu.20.04
@@ -7,33 +7,59 @@
 FROM ubuntu:20.04
 LABEL org.opencontainers.image.authors="daos@daos.groups.io"
 
-# use same UID as host and default value of 1000 if not specified
-ARG UID=1000
-ARG REPO_URL=""
-ARG REPO_UBUNTU_20_04=""
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    curl gpg
+
+ARG REPO_FILE_URL
+RUN if [ -n "$REPO_FILE_URL" ]; then                                 \
+        cd /etc/apt/sources.list.d &&                                \
+        curl -f -o daos_ci-ubuntu20.04-artifactory.list.tmp          \
+             "$REPO_FILE_URL"daos_ci-ubuntu20.04-artifactory.list && \
+        true > ../sources.list &&                                    \
+        mv daos_ci-ubuntu20.04-artifactory.list.tmp                  \
+           daos_ci-ubuntu20.04-artifactory.list;                     \
+    fi;                                                              \
+    cd -;                                                            \
+    curl -f -O "$REPO_FILE_URL"esad_repo.key;                        \
+    gpg --no-default-keyring --keyring ./temp-keyring.gpg            \
+        --import esad_repo.key;                                      \
+    mkdir -p /usr/local/share/keyrings/;                             \
+    gpg --no-default-keyring --keyring ./temp-keyring.gpg --export   \
+        --output /usr/local/share/keyrings/daos-stack-public.gpg;    \
+    rm ./temp-keyring.gpg;                                           \
+    url_prefix=https://downloads.linux.hpe.com/SDR/;                 \
+    for url in hpPublicKey2048.pub                                   \
+               hpPublicKey2048_key1.pub                              \
+               hpePublicKey2048_key1.pub; do                         \
+        curl -f -O "$url_prefix$url";                                \
+        gpg --no-default-keyring --keyring ./temp-keyring.gpg        \
+            --import "$(basename $url)";                             \
+    done;                                                            \
+    gpg --no-default-keyring --keyring ./temp-keyring.gpg --export   \
+        --output /usr/local/share/keyrings/hpe-sdr-public.gpg;       \
+    rm ./temp-keyring.gpg
 
 # Install basic tools
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
             autoconf bash ca-certificates curl debhelper dh-make        \
             dpkg-dev dh-python doxygen gcc git git-buildpackage locales \
             make patch pbuilder pkg-config python3-dev python3-distro   \
-            python3-distutils rpm scons wget cmake valgrind
+            python3-distutils rpm scons wget cmake valgrind rpmdevtools
 
-# rpmdevtools
-RUN echo "deb [trusted=yes] ${REPO_URL}${REPO_UBUNTU_20_04} focal main" > /etc/apt/sources.list.d/daos-stack-ubuntu-stable-local.list
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-            rpmdevtools
+# use same UID as host and default value of 1000 if not specified
+ARG UID=1000
 
 # Add build user (to keep chrootbuild happy)
 ENV USER build
 RUN useradd -u $UID -ms /bin/bash $USER
 
 # need to run the build command as root, as it needs to chroot
-RUN if ! grep "^#includedir /etc/sudoers.d" /etc/sudoers; then                          \
-        echo "#includedir /etc/sudoers.d" >> /etc/sudoers;                              \
-    fi;                                                                                 \
-    echo "Defaults env_keep += \"DPKG_GENSYMBOLS_CHECK_LEVEL\"" > /etc/sudoers.d/build; \
-    echo "build ALL=(ALL) NOPASSWD: /usr/sbin/pbuilder" >> /etc/sudoers.d/build;        \
-    chmod 0440 /etc/sudoers.d/build;                                                    \
-    visudo -c;                                                                          \
+RUN if ! grep "^#includedir /etc/sudoers.d" /etc/sudoers; then                                     \
+        echo "#includedir /etc/sudoers.d" >> /etc/sudoers;                                         \
+    fi;                                                                                            \
+    echo "Defaults env_keep += \"DPKG_GENSYMBOLS_CHECK_LEVEL\"" > /etc/sudoers.d/build;            \
+    echo "build ALL=(ALL) NOPASSWD: /usr/bin/tee /root/.pbuilderrc" >> /etc/sudoers.d/build; \
+    echo "build ALL=(ALL) NOPASSWD: /usr/sbin/pbuilder" >> /etc/sudoers.d/build;                   \
+    chmod 0440 /etc/sudoers.d/build;                                                               \
+    visudo -c;                                                                                     \
     sudo -l -U build

--- a/packaging/Makefile_packaging.mk
+++ b/packaging/Makefile_packaging.mk
@@ -317,20 +317,6 @@ patch:
 	echo "PKG_GIT_COMMIT is not defined"
 endif
 
-# *_LOCAL_* repos are locally built packages.
-ifeq ($(LOCAL_REPOS),true)
-  ifneq ($(ARTIFACTORY_URL),)
-    ifneq ($(DAOS_STACK_$(DISTRO_BASE)_LOCAL_REPO),)
-      DISTRO_REPOS = disabled # any non-empty value here works and is not used beyond testing if the value is empty or not
-	  # convert to artifactory url
-      DAOS_STACK_$(DISTRO_BASE)_LOCAL_REPO := $(subst reposi,artifac,$(DAOS_STACK_$(DISTRO_BASE)_LOCAL_REPO))
-      # $(DISTRO_BASE)_LOCAL_REPOS is a list separated by | because you cannot pass lists
-      # of values with spaces as environment variables
-      $(DISTRO_BASE)_LOCAL_REPOS := [trusted=yes] $(ARTIFACTORY_URL)$(subst stack,stack-daos,$(DAOS_STACK_$(DISTRO_BASE)_LOCAL_REPO))
-      $(DISTRO_BASE)_LOCAL_REPOS += |[trusted=yes] $(ARTIFACTORY_URL)$(subst stack,stack-deps,$(DAOS_STACK_$(DISTRO_BASE)_LOCAL_REPO))
-    endif #ifneq ($(DAOS_STACK_$(DISTRO_BASE)_LOCAL_REPO),)
-  endif # ifneq ($(ARTIFACTORY_URL),)
-endif # ifeq ($(LOCAL_REPOS),true)
 ifeq ($(ID_LIKE),debian)
 chrootbuild: $(DEB_TOP)/$(DEB_DSC)
 	$(call distro_map)                                      \
@@ -346,6 +332,8 @@ chrootbuild: $(DEB_TOP)/$(DEB_DSC)
 	DEB_TOP="$(DEB_TOP)"                                    \
 	DEB_DSC="$(DEB_DSC)"                                    \
 	DISTRO_ID_OPT="$(DISTRO_ID_OPT)"                        \
+	LOCAL_REPOS='$(LOCAL_REPOS)'                            \
+	ARTIFACTORY_URL="$(ARTIFACTORY_URL)"                    \
 	packaging/debian_chrootbuild
 else
 chrootbuild: $(SRPM) $(CALLING_MAKEFILE)
@@ -360,7 +348,7 @@ chrootbuild: $(SRPM) $(CALLING_MAKEFILE)
 	REPO_FILE_URL="$(REPO_FILE_URL)"                        \
 	MOCK_OPTIONS="$(MOCK_OPTIONS)"                          \
 	RPM_BUILD_OPTIONS='$(RPM_BUILD_OPTIONS)'                \
-	DISTRO_REPOS='$(DISTRO_REPOS)'                          \
+	LOCAL_REPOS='$(LOCAL_REPOS)'                            \
 	ARTIFACTORY_URL="$(ARTIFACTORY_URL)"                    \
 	DISTRO_VERSION="$(DISTRO_VERSION)"                      \
 	TARGET="$<"                                             \

--- a/packaging/debian_chrootbuild
+++ b/packaging/debian_chrootbuild
@@ -2,14 +2,13 @@
 
 set -uex
 
-# shellcheck disable=SC2153
-IFS=\| read -r -a distro_base_local_repos <<< "$DISTRO_BASE_LOCAL_REPOS"
+if [ -n "${ARTIFACTORY_URL:-}" ] && "$LOCAL_REPOS"; then
+    echo "MIRRORSITE=${ARTIFACTORY_URL}artifactory/ubuntu-proxy" | sudo tee /root/.pbuilderrc
+fi
 
 # shellcheck disable=SC2086
-sudo pbuilder create                                                                                                                                                           \
-    --extrapackages "gnupg ca-certificates"                                                                                                                                    \
-    --othermirror                                                                                                                                                              \
-    "deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ $VERSION_CODENAME universe|deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ $VERSION_CODENAME-updates main universe" \
+sudo pbuilder create                        \
+    --extrapackages "gnupg ca-certificates" \
     $DISTRO_ID_OPT
 
 repo_args=""
@@ -26,13 +25,18 @@ for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
     fi
     repo_args="$repo_args|deb [trusted=yes] ${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/$DISTRO/ ./"
 done
-for repo in $JOB_REPOS "${distro_base_local_repos[@]}"; do
-    repo_args="$repo_args|deb ${repo} $VERSION_CODENAME main"
+
+repo_args+="|$(curl -sSf "$REPO_FILE_URL"daos_ci-"$DISTRO"-artifactory.list |
+            sed -e 's/#.*//' -e '/ubuntu-proxy/d' -e '/^$/d' -e '/^$/d'     \
+                -e 's/signed-by=.*\.gpg/trusted=yes/'                       |
+            sed -e ':a; N; $!ba; s/\n/|/g')"
+for repo in $JOB_REPOS; do
+    repo_args+="|deb ${repo} $VERSION_CODENAME main"
 done
 # NB: This PPA is needed to support modern go toolchains on ubuntu 20.04.
 # After the build is updated to use 22.04, which supports go >= 1.18, it
 # should no longer be needed.
-repo_args="$repo_args|deb [trusted=yes] https://ppa.launchpadcontent.net/longsleep/golang-backports/ubuntu focal main"
+repo_args="$repo_args|deb [trusted=yes] https://ppa.launchpadcontent.net/longsleep/golang-backports/ubuntu $VERSION_CODENAME main"
 echo "$repo_args"
 if [ "$repo_args" = "|" ]; then
     repo_args=""

--- a/packaging/rpm_chrootbuild
+++ b/packaging/rpm_chrootbuild
@@ -39,8 +39,7 @@ repo_dels=()
 
 echo -e "config_opts['yum.conf'] += \"\"\"\n" >> "$cfg_file"
 
-if [ -n "${ARTIFACTORY_URL:-}" ] &&
-   [ -n "$DISTRO_REPOS" ]; then
+if [ -n "${ARTIFACTORY_URL:-}" ] && "$LOCAL_REPOS"; then
     repo_dels+=("--disablerepo=\*")
 
     if [ -n "${REPO_FILE_URL:-}" ]; then

--- a/raft.spec
+++ b/raft.spec
@@ -9,8 +9,8 @@
 %global debug_package %{nil}
 
 Name:		raft
-Version:	0.9.1
-Release:	2%{?relval}%{?dist}
+Version:	0.9.2
+Release:	1%{?relval}%{?dist}
 
 Summary:	C implementation of the Raft Consensus protocol, BSD licensed
 Provides:	daos-raft = %version-%release%{?dist}
@@ -62,6 +62,9 @@ cp -a include/* %{buildroot}/%{_includedir}
 
 
 %changelog
+* Mon Feb 13 2023 Li Wei <wei.g.li@intel.com> -0.9.2-1
+- Fix assertion failures in raft_recv_requestvote
+
 * Fri Nov 25 2022 Brian J. Murrell <brian.murrell@intel> -0.9.1-2
 - Change BuildArchitectures: noarch
 


### PR DESCRIPTION
A failure of the following assertion in raft_recv_requestvote was
observed:

    assert(!raft_is_leader(me_) &&
           (vr->prevote || !raft_is_candidate(me_)));

At the time, this server was very unlikely a leader. So it must be a
candidate granting a non-prevote RV request. Since a candidate votes for
itself only when becoming a _prevoted_ candidate, the server must be a
_prevoting_ candidate. This patch fixes the assertion to allow such a
valid case.

Related, raft_become_prevoted_candidate clears me->prevote too early. If
the raft_set_current_term call or the raft_vote_for_nodeid call returns
an error, the server is left as a prevoted candidate, but hasn't voted
for itself. If a non-prevote RV request comes in, the server may grant
the vote and fail the assertion above. This patch changes
raft_become_prevoted_candidate to exit the prevoting phase after the
self vote succeeds.

Signed-off-by: Li Wei <wei.g.li@intel.com>