### PR TITLE
DAOS-2424 server: Introduce raft_time_t

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ We need to call ``raft_periodic`` at periodic intervals.
 
 .. code-block:: c
 
-    raft_periodic(raft, 1000);
+    raft_periodic(raft);
 
 *Example using a libuv timer:*
 
@@ -99,7 +99,7 @@ We need to call ``raft_periodic`` at periodic intervals.
 
     static void __periodic(uv_timer_t* handle)
     {
-        raft_periodic(sv->raft, PERIOD_MSEC);
+        raft_periodic(sv->raft);
     }
 
     uv_timer_t *periodic_req;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+raft (0.10.0-1) unstable; urgency=medium
+
+  [ Li Wei ]
+  * Add leadership lease
+  * Let leaders step down voluntarily when they can't maintain leases from majority
+
+ -- Li Wei <wei.g.li@intel.com>  Mon, 05 Jun 2023 09:07:00 +0900
+
 raft (0.9.2-1) unstable; urgency=medium
 
   [ Li Wei ]

--- a/include/raft.h
+++ b/include/raft.h
@@ -451,6 +451,17 @@ typedef void (
     raft_membership_e type
     );
 
+/** Callback for getting the current time.
+ * @param[in] raft The Raft server making this callback
+ * @param[in] user_data User data that is passed from Raft server
+ * @return The current time */
+typedef raft_time_t (
+*func_get_time_f
+)   (
+    raft_server_t* raft,
+    void *user_data
+    );
+
 typedef struct
 {
     /** Callback for sending request vote messages */
@@ -515,6 +526,9 @@ typedef struct
     /** Callback for catching debugging log messages
      * This callback is optional */
     func_log_f log;
+
+    /** Callback for getting the current time */
+    func_get_time_f get_time;
 } raft_cbs_t;
 
 typedef struct
@@ -589,12 +603,11 @@ void raft_set_election_timeout(raft_server_t* me, int msec);
 void raft_set_request_timeout(raft_server_t* me, int msec);
 
 /** Process events that are dependent on time passing.
- * @param[in] msec_elapsed Time in milliseconds since the last call
  * @return
  *  0 on success;
  *  -1 on failure;
  *  RAFT_ERR_SHUTDOWN when server MUST shutdown */
-int raft_periodic(raft_server_t* me, int msec_elapsed);
+int raft_periodic(raft_server_t* me);
 
 /** Receive an appendentries message.
  *

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -47,6 +47,9 @@ typedef struct {
     /* true if this server is in the candidate prevote state (§4.2.3, §9.6) */
     int prevote;
 
+    /* start time of this server */
+    raft_time_t start_time;
+
     /* start time of election timer */
     raft_time_t election_timer;
  
@@ -80,6 +83,13 @@ typedef struct {
     /* Last compacted snapshot */
     raft_index_t snapshot_last_idx;
     raft_term_t snapshot_last_term;
+
+    /* grace period after each lease expiration time honored when we determine
+     * if a leader is maintaining leases from a majority (see raft_periodic) */
+    int lease_maintenance_grace;
+
+    /* represents the first start of this (persistent) server; not a restart */
+    int first_start;
 } raft_server_private_t;
 
 int raft_become_candidate(raft_server_t* me);
@@ -132,6 +142,12 @@ void raft_node_vote_for_me(raft_node_t* me_, const int vote);
 int raft_node_has_vote_for_me(raft_node_t* me_);
 
 void raft_node_set_has_sufficient_logs(raft_node_t* me_);
+
+void raft_node_set_lease(raft_node_t* me_, raft_time_t lease);
+
+void raft_node_set_effective_time(raft_node_t* me_, raft_time_t effective_time);
+
+raft_time_t raft_node_get_effective_time(raft_node_t* me_);
 
 int raft_votes_is_majority(const int nnodes, const int nvotes);
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -47,8 +47,8 @@ typedef struct {
     /* true if this server is in the candidate prevote state (§4.2.3, §9.6) */
     int prevote;
 
-    /* amount of time left till timeout */
-    int timeout_elapsed;
+    /* start time of election timer */
+    raft_time_t election_timer;
  
     raft_node_t* nodes;
     int num_nodes;

--- a/include/raft_types.h
+++ b/include/raft_types.h
@@ -27,4 +27,9 @@ typedef long int raft_index_t;
  */
 typedef int raft_node_id_t;
 
+/**
+ * Timestamp in milliseconds.
+ */
+typedef long int raft_time_t;
+
 #endif  /* RAFT_DEFS_H_ */

--- a/raft.spec
+++ b/raft.spec
@@ -9,7 +9,7 @@
 %global debug_package %{nil}
 
 Name:		raft
-Version:	0.9.2
+Version:	0.10.0
 Release:	1%{?relval}%{?dist}
 
 Summary:	C implementation of the Raft Consensus protocol, BSD licensed
@@ -62,6 +62,10 @@ cp -a include/* %{buildroot}/%{_includedir}
 
 
 %changelog
+* Mon Jun 05 2023 Li Wei <wei.g.li@intel.com> -0.10.0-1
+- Add leadership lease
+- Let leaders step down voluntarily when they can't maintain leases from majority
+
 * Mon Feb 13 2023 Li Wei <wei.g.li@intel.com> -0.9.2-1
 - Fix assertion failures in raft_recv_requestvote
 

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -30,6 +30,11 @@ typedef struct
     int flags;
 
     raft_node_id_t id;
+
+    /* lease expiration time */
+    raft_time_t lease;
+    /* time when this node becomes part of leader's configuration */
+    raft_time_t effective_time;
 } raft_node_private_t;
 
 raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
@@ -43,6 +48,8 @@ raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
     me->match_idx = 0;
     me->id = id;
     me->flags = RAFT_NODE_VOTING;
+    me->lease = 0;
+    me->effective_time = 0;
     return (raft_node_t*)me;
 }
 
@@ -140,4 +147,29 @@ raft_node_id_t raft_node_get_id(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return (NULL == me) ? -1 : me->id;
+}
+
+void raft_node_set_lease(raft_node_t* me_, raft_time_t lease)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    if (me->lease < lease)
+        me->lease = lease;
+}
+
+raft_time_t raft_node_get_lease(raft_node_t* me_)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    return me->lease;
+}
+
+void raft_node_set_effective_time(raft_node_t* me_, raft_time_t effective_time)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    me->effective_time = effective_time;
+}
+
+raft_time_t raft_node_get_effective_time(raft_node_t* me_)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    return me->effective_time;
 }

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -32,6 +32,18 @@ void raft_set_request_timeout(raft_server_t* me_, int millisec)
     me->request_timeout = millisec;
 }
 
+void raft_set_lease_maintenance_grace(raft_server_t* me_, int millisec)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    me->lease_maintenance_grace = millisec;
+}
+
+void raft_set_first_start(raft_server_t* me_)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    me->first_start = 1;
+}
+
 void raft_set_nodeid(raft_server_t* me_, raft_node_id_t id)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
@@ -53,6 +65,11 @@ int raft_get_election_timeout(raft_server_t* me_)
 int raft_get_request_timeout(raft_server_t* me_)
 {
     return ((raft_server_private_t*)me_)->request_timeout;
+}
+
+int raft_get_lease_maintenance_grace(raft_server_t* me_)
+{
+    return ((raft_server_private_t*)me_)->lease_maintenance_grace;
 }
 
 int raft_get_num_nodes(raft_server_t* me_)

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -72,7 +72,8 @@ int raft_get_num_voting_nodes(raft_server_t* me_)
 
 int raft_get_timeout_elapsed(raft_server_t* me_)
 {
-    return ((raft_server_private_t*)me_)->timeout_elapsed;
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    return me->cb.get_time(me_, me->udata) - me->election_timer;
 }
 
 raft_index_t raft_get_log_count(raft_server_t* me_)

--- a/tests/test_log.c
+++ b/tests/test_log.c
@@ -79,9 +79,20 @@ static int __log_pop_failing(
     return -1;
 }
 
+static raft_time_t __raft_clock = 1000000;
+
+static raft_time_t __raft_get_time(
+    raft_server_t* raft,
+    void *user_data
+    )
+{
+    return __raft_clock;
+}
+
 raft_cbs_t g_funcs = {
     .log_pop = __log_pop,
-    .log_get_node_id = __logentry_get_node_id
+    .log_get_node_id = __logentry_get_node_id,
+    .get_time = __raft_get_time
 };
 
 static int log_append_entry(log_t* me_, raft_entry_t* ety)
@@ -175,7 +186,8 @@ void TestLog_delete(CuTest * tc)
     void *r = raft_new();
     raft_cbs_t funcs = {
         .log_pop = __log_pop,
-        .log_get_node_id = __logentry_get_node_id
+        .log_get_node_id = __logentry_get_node_id,
+        .get_time = __raft_get_time
     };
     raft_set_callbacks(r, &funcs, queue);
 
@@ -219,7 +231,8 @@ void TestLog_delete_onwards(CuTest * tc)
     void *r = raft_new();
     raft_cbs_t funcs = {
         .log_pop = __log_pop,
-        .log_get_node_id = __logentry_get_node_id
+        .log_get_node_id = __logentry_get_node_id,
+        .get_time = __raft_get_time
     };
     raft_set_callbacks(r, &funcs, queue);
 
@@ -260,7 +273,8 @@ void TestLog_delete_handles_log_pop_failure(CuTest * tc)
     void *r = raft_new();
     raft_cbs_t funcs = {
         .log_pop = __log_pop_failing,
-        .log_get_node_id = __logentry_get_node_id
+        .log_get_node_id = __logentry_get_node_id,
+        .get_time = __raft_get_time
     };
     raft_set_callbacks(r, &funcs, queue);
 
@@ -293,7 +307,8 @@ void TestLog_delete_fails_for_idx_zero(CuTest * tc)
     void *r = raft_new();
     raft_cbs_t funcs = {
         .log_pop = __log_pop,
-        .log_get_node_id = __logentry_get_node_id
+        .log_get_node_id = __logentry_get_node_id,
+        .get_time = __raft_get_time
     };
     raft_set_callbacks(r, &funcs, queue);
 
@@ -331,7 +346,8 @@ void TestLog_delete_processes_cfg_entries(CuTest * tc)
     void *r = raft_new();
     raft_cbs_t funcs = {
         .log_pop = __log_pop,
-        .log_get_node_id = __logentry_get_node_id_check
+        .log_get_node_id = __logentry_get_node_id_check,
+        .get_time = __raft_get_time
     };
     raft_set_callbacks(r, &funcs, queue);
 
@@ -396,7 +412,8 @@ void TestLog_poll(CuTest * tc)
     void *r = raft_new();
     raft_cbs_t funcs = {
         .log_pop = __log_pop,
-        .log_get_node_id = __logentry_get_node_id
+        .log_get_node_id = __logentry_get_node_id,
+        .get_time = __raft_get_time
     };
     raft_set_callbacks(r, &funcs, queue);
 
@@ -454,7 +471,8 @@ void TestLog_delete_batches(CuTest * tc)
     void *r = raft_new();
     raft_cbs_t funcs = {
         .log_pop = __log_pop,
-        .log_get_node_id = __logentry_get_node_id
+        .log_get_node_id = __logentry_get_node_id,
+        .get_time = __raft_get_time
     };
     raft_set_callbacks(r, &funcs, queue);
 
@@ -687,7 +705,8 @@ void TestLog_delete_after_polling_from_double_append(CuTest * tc)
     void *r = raft_new();
     raft_cbs_t funcs = {
         .log_pop = __log_pop,
-        .log_get_node_id = __logentry_get_node_id
+        .log_get_node_id = __logentry_get_node_id,
+        .get_time = __raft_get_time
     };
     raft_set_callbacks(r, &funcs, queue);
 
@@ -732,7 +751,8 @@ void TestLog_get_from_idx_with_base_off_by_one(CuTest * tc)
     void *r = raft_new();
     raft_cbs_t funcs = {
         .log_pop = __log_pop,
-        .log_get_node_id = __logentry_get_node_id
+        .log_get_node_id = __logentry_get_node_id,
+        .get_time = __raft_get_time
     };
     raft_set_callbacks(r, &funcs, queue);
 

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -123,6 +123,14 @@ static int max_election_timeout(int election_timeout)
 	return 2 * election_timeout;
 }
 
+/* During the first election timoeut after it starts, a server does not
+ * consider incoming vote requests. Advance the clock by an election timeout,
+ * so that the server begins to consider incoming vote requests. */
+static void wait_for_startup_lease(raft_server_t* r)
+{
+    __raft_clock += raft_get_election_timeout(r);
+}
+
 void TestRaft_server_voted_for_records_who_we_voted_for(CuTest * tc)
 {
     void *r = raft_new();
@@ -1036,6 +1044,7 @@ void TestRaft_server_recv_requestvote_reply_false_if_term_less_than_current_term
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
     raft_set_current_term(r, 2);
+    wait_for_startup_lease(r);
 
     /* term is less than current term */
     msg_requestvote_t rv;
@@ -1067,6 +1076,7 @@ void TestRaft_leader_recv_requestvote_does_not_step_down(
     raft_add_node(r, NULL, 2, 0);
     raft_set_current_term(r, 1);
     raft_vote(r, raft_get_node(r, 1));
+    wait_for_startup_lease(r);
     raft_become_leader(r);
     CuAssertIntEquals(tc, 1, raft_is_leader(r));
 
@@ -1092,8 +1102,9 @@ void TestRaft_server_recv_requestvote_reply_true_if_term_greater_than_or_equal_t
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
     raft_set_current_term(r, 1);
+    wait_for_startup_lease(r);
 
-    /* term is less than current term */
+    /* term is greater than current term */
     memset(&rv, 0, sizeof(msg_requestvote_t));
     rv.term = 2;
     rv.last_log_idx = 1;
@@ -1115,10 +1126,8 @@ void TestRaft_server_recv_prevote_dont_grant_real_vote(
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
     raft_set_current_term(r, 1);
-
     raft_set_election_timeout(r, 1000);
-    __raft_clock += 900;
-    raft_periodic(r);
+    wait_for_startup_lease(r);
 
     /* grant prevote but not real vote */
     memset(&rv, 0, sizeof(msg_requestvote_t));
@@ -1153,11 +1162,9 @@ void TestRaft_server_recv_requestvote_reset_timeout(
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
     raft_set_current_term(r, 1);
-
     raft_set_election_timeout(r, 1000);
-    __raft_clock += 900;
-    raft_periodic(r);
-    CuAssertIntEquals(tc, 900, raft_get_timeout_elapsed(r));
+    wait_for_startup_lease(r);
+    CuAssertTrue(tc, 0 < raft_get_timeout_elapsed(r));
 
     memset(&rv, 0, sizeof(msg_requestvote_t));
     rv.term = 2;
@@ -1183,6 +1190,8 @@ void TestRaft_server_recv_requestvote_candidate_step_down_if_term_is_higher_than
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
+    wait_for_startup_lease(r);
+
     raft_become_candidate(r);
     raft_become_prevoted_candidate(r);
     raft_set_current_term(r, 1);
@@ -1217,6 +1226,8 @@ void TestRaft_server_recv_requestvote_depends_on_candidate_id(
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
+    wait_for_startup_lease(r);
+
     raft_become_candidate(r);
     raft_become_prevoted_candidate(r);
     raft_set_current_term(r, 1);
@@ -1248,6 +1259,7 @@ void TestRaft_server_recv_requestvote_dont_grant_vote_if_we_didnt_vote_for_this_
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
     raft_set_current_term(r, 1);
+    wait_for_startup_lease(r);
 
     /* votedFor is null; vote for 0 */
     msg_requestvote_t rv = {};
@@ -1282,6 +1294,7 @@ void TestRaft_server_recv_prevote_ignore_if_master_is_fresh(CuTest * tc)
     raft_add_node(r, NULL, 2, 0);
     raft_set_current_term(r, 1);
     raft_set_election_timeout(r, 1000);
+    wait_for_startup_lease(r);
 
     msg_appendentries_t ae = { 0 };
     msg_appendentries_response_t aer;
@@ -1321,6 +1334,7 @@ void TestRaft_server_recv_requestvote_ignore_if_master_is_fresh(CuTest * tc)
     raft_add_node(r, NULL, 2, 0);
     raft_set_current_term(r, 1);
     raft_set_election_timeout(r, 1000);
+    wait_for_startup_lease(r);
 
     msg_appendentries_t ae = { 0 };
     msg_appendentries_response_t aer;
@@ -1350,6 +1364,7 @@ void TestRaft_server_recv_requestvote_ignore_local_membership(CuTest * tc)
 {
     void* r = raft_new();
     raft_set_callbacks(r, &generic_funcs, NULL);
+    wait_for_startup_lease(r);
 
     /* empty local membership */
     msg_requestvote_t rv = {
@@ -2121,6 +2136,7 @@ void TestRaft_follower_dont_grant_prevote_if_candidate_has_a_less_complete_log(
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
+    wait_for_startup_lease(r);
 
     /*  request prevote */
     /*  prevote indicates candidate's log is not complete compared to follower */
@@ -2172,6 +2188,7 @@ void TestRaft_follower_dont_grant_vote_if_candidate_has_a_less_complete_log(
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
+    wait_for_startup_lease(r);
 
     /*  request vote */
     /*  vote indicates candidate's log is not complete compared to follower */
@@ -2448,6 +2465,27 @@ void TestRaft_follower_recv_appendentries_resets_election_timeout(
     CuAssertTrue(tc, 0 == raft_get_timeout_elapsed(r));
 }
 
+void TestRaft_follower_recv_appendentries_reply_lease(
+    CuTest * tc)
+{
+    void *r = raft_new();
+    raft_set_callbacks(r, &generic_funcs, NULL);
+
+    raft_set_election_timeout(r, 1000);
+    raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 1);
+
+    raft_time_t t = __raft_clock;
+
+    msg_appendentries_t ae;
+    msg_appendentries_response_t aer;
+
+    memset(&ae, 0, sizeof(msg_appendentries_t));
+    ae.term = 1;
+    raft_recv_appendentries(r, raft_get_node(r, 1), &ae, &aer);
+    CuAssertIntEquals(tc, t + raft_get_election_timeout(r), aer.lease);
+}
+
 /* Candidate 5.2 */
 void TestRaft_follower_becoming_candidate_requests_votes_from_other_servers(
     CuTest * tc)
@@ -2593,6 +2631,7 @@ void TestRaft_candidate_will_not_respond_to_voterequest_if_it_has_already_voted(
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
+    wait_for_startup_lease(r);
 
     raft_vote(r, raft_get_node(r, 1));
 
@@ -2652,6 +2691,7 @@ void TestRaft_candidate_recv_requestvote_response_becomes_follower_if_current_te
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
+    wait_for_startup_lease(r);
 
     raft_set_current_term(r, 1);
     raft_set_state(r, RAFT_STATE_CANDIDATE);
@@ -2680,6 +2720,7 @@ void TestRaft_candidate_may_grant_prevote_if_term_not_less_than_current_term(
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
+    wait_for_startup_lease(r);
 
     raft_set_current_term(r, 1);
     raft_become_candidate(r);
@@ -2726,6 +2767,7 @@ void TestRaft_candidate_grant_prevote(
     CuAssertTrue(tc, aer.success);
     CuAssertIntEquals(tc, 2, raft_get_current_leader(r));
 
+    wait_for_startup_lease(r);
     raft_become_candidate(r);
 
     /* candidate grants prevote */
@@ -2747,6 +2789,7 @@ void TestRaft_candidate_recv_requestvote_may_grant_vote(
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
     raft_add_node(r, NULL, 3, 0);
+    wait_for_startup_lease(r);
 
     /* receive AE from leader */
     msg_appendentries_t ae;
@@ -2974,7 +3017,7 @@ void TestRaft_leader_responds_to_entry_msg_when_entry_is_committed(CuTest * tc)
     raft_add_node(r, NULL, 2, 0);
 
     /* I am the leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
+    raft_become_leader(r);
     CuAssertTrue(tc, 0 == raft_get_log_count(r));
 
     /* entry message */
@@ -3030,7 +3073,7 @@ void TestRaft_leader_sends_appendentries_with_NextIdx_when_PrevIdx_gt_NextIdx(
     raft_add_node(r, NULL, 2, 0);
 
     /* i'm leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
+    raft_become_leader(r);
 
     raft_entry_t etys[3] = {};
     raft_index_t i;
@@ -3068,7 +3111,12 @@ void TestRaft_leader_sends_appendentries_with_leader_commit(
     raft_add_node(r, NULL, 2, 0);
 
     /* i'm leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
+    raft_become_leader(r);
+
+    /* receive appendentries messages sent by the raft_became_leader call */
+    msg_appendentries_t*  ae = sender_poll_msg_data(sender);
+    CuAssertTrue(tc, NULL != ae);
+    CuAssertIntEquals(tc, 0, ae->leader_commit);
 
     raft_index_t i;
 
@@ -3086,9 +3134,9 @@ void TestRaft_leader_sends_appendentries_with_leader_commit(
 
     /* receive appendentries messages */
     raft_send_appendentries(r, raft_get_node(r, 2));
-    msg_appendentries_t*  ae = sender_poll_msg_data(sender);
+    ae = sender_poll_msg_data(sender);
     CuAssertTrue(tc, NULL != ae);
-    CuAssertTrue(tc, ae->leader_commit == 10);
+    CuAssertIntEquals(tc, 10, ae->leader_commit);
 }
 
 void TestRaft_leader_sends_appendentries_with_prevLogIdx(
@@ -3107,10 +3155,9 @@ void TestRaft_leader_sends_appendentries_with_prevLogIdx(
     raft_add_node(r, NULL, 2, 0);
 
     /* i'm leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
+    raft_become_leader(r);
 
-    /* receive appendentries messages */
-    raft_send_appendentries(r, raft_get_node(r, 2));
+    /* receive appendentries messages sent by the raft_become_leader call */
     msg_appendentries_t*  ae = sender_poll_msg_data(sender);
     CuAssertTrue(tc, NULL != ae);
     CuAssertTrue(tc, ae->prev_log_idx == 0);
@@ -3159,7 +3206,7 @@ void TestRaft_leader_sends_appendentries_when_node_has_next_idx_of_0(
     raft_add_node(r, NULL, 2, 0);
 
     /* i'm leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
+    raft_become_leader(r);
 
     /* receive appendentries messages */
     raft_send_appendentries(r, raft_get_node(r, 2));
@@ -3198,7 +3245,7 @@ void TestRaft_leader_retries_appendentries_with_decremented_NextIdx_log_inconsis
     raft_add_node(r, NULL, 2, 0);
 
     /* i'm leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
+    raft_become_leader(r);
 
     /* receive appendentries messages */
     raft_send_appendentries(r, raft_get_node(r, 2));
@@ -3228,7 +3275,7 @@ void TestRaft_leader_append_entry_to_log_increases_idxno(CuTest * tc)
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
-    raft_set_state(r, RAFT_STATE_LEADER);
+    raft_become_leader(r);
     CuAssertTrue(tc, 0 == raft_get_log_count(r));
 
     raft_recv_entry(r, &ety, &cr);
@@ -3256,7 +3303,7 @@ void T_estRaft_leader_doesnt_append_entry_if_unique_id_is_duplicate(CuTest * tc)
     r = raft_new();
     raft_set_configuration(r, cfg, 0);
 
-    raft_set_state(r, RAFT_STATE_LEADER);
+    raft_become_leader(r);
     CuAssertTrue(tc, 0 == raft_get_log_count(r));
 
     raft_recv_entry(r, 1, &ety);
@@ -3289,8 +3336,8 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_when_majori
     raft_set_callbacks(r, &funcs, sender);
 
     /* I'm the leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 1);
+    raft_become_leader(r);
     raft_set_commit_idx(r, 0);
     /* the last applied idx will became 1, and then 2 */
     raft_set_last_applied_idx(r, 0);
@@ -3319,6 +3366,7 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_when_majori
     aer.success = 1;
     aer.current_idx = 1;
     aer.first_idx = 1;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 0, raft_get_commit_idx(r));
     raft_recv_appendentries_response(r, raft_get_node(r, 3), &aer);
@@ -3338,6 +3386,7 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_when_majori
     aer.success = 1;
     aer.current_idx = 2;
     aer.first_idx = 2;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 1, raft_get_commit_idx(r));
     raft_recv_appendentries_response(r, raft_get_node(r, 3), &aer);
@@ -3371,8 +3420,8 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_for_nod
     raft_set_callbacks(r, &funcs, &has_sufficient_logs_flag);
 
     /* I'm the leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 1);
+    raft_become_leader(r);
     raft_set_commit_idx(r, 0);
     /* the last applied idx will became 1, and then 2 */
     raft_set_last_applied_idx(r, 0);
@@ -3396,6 +3445,7 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_for_nod
     aer.success = 1;
     aer.current_idx = 2;
     aer.first_idx = 1;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
 
     raft_node_set_voting(node, 0);
     raft_recv_appendentries_response(r, node, &aer);
@@ -3427,8 +3477,8 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_using_votin
     raft_set_callbacks(r, &funcs, sender);
 
     /* I'm the leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 1);
+    raft_become_leader(r);
     raft_set_commit_idx(r, 0);
     /* the last applied idx will became 1, and then 2 */
     raft_set_last_applied_idx(r, 0);
@@ -3452,6 +3502,7 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_using_votin
     aer.success = 1;
     aer.current_idx = 1;
     aer.first_idx = 1;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 1, raft_get_commit_idx(r));
     /* leader will now have majority followers who have appended this log */
@@ -3479,8 +3530,8 @@ void TestRaft_leader_recv_appendentries_response_duplicate_does_not_decrement_ma
     raft_set_callbacks(r, &funcs, sender);
 
     /* I'm the leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 1);
+    raft_become_leader(r);
     raft_set_commit_idx(r, 0);
     /* the last applied idx will became 1, and then 2 */
     raft_set_last_applied_idx(r, 0);
@@ -3504,6 +3555,7 @@ void TestRaft_leader_recv_appendentries_response_duplicate_does_not_decrement_ma
     aer.success = 1;
     aer.current_idx = 1;
     aer.first_idx = 1;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 1, raft_node_get_match_idx(raft_get_node(r, 2)));
 
@@ -3512,6 +3564,7 @@ void TestRaft_leader_recv_appendentries_response_duplicate_does_not_decrement_ma
     aer.success = 1;
     aer.current_idx = 2;
     aer.first_idx = 2;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 2, raft_node_get_match_idx(raft_get_node(r, 2)));
 
@@ -3520,6 +3573,7 @@ void TestRaft_leader_recv_appendentries_response_duplicate_does_not_decrement_ma
     aer.success = 1;
     aer.current_idx = 1;
     aer.first_idx = 1;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 2, raft_node_get_match_idx(raft_get_node(r, 2)));
 }
@@ -3546,8 +3600,8 @@ void TestRaft_leader_recv_appendentries_response_do_not_increase_commit_idx_beca
     raft_add_node(r, NULL, 5, 0);
     raft_set_callbacks(r, &funcs, sender);
 
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 2);
+    raft_become_leader(r);
     raft_set_commit_idx(r, 0);
     raft_set_last_applied_idx(r, 0);
 
@@ -3576,6 +3630,7 @@ void TestRaft_leader_recv_appendentries_response_do_not_increase_commit_idx_beca
     aer.success = 1;
     aer.current_idx = 1;
     aer.first_idx = 1;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 0, raft_get_commit_idx(r));
     raft_recv_appendentries_response(r, raft_get_node(r, 3), &aer);
@@ -3594,6 +3649,7 @@ void TestRaft_leader_recv_appendentries_response_do_not_increase_commit_idx_beca
     aer.success = 1;
     aer.current_idx = 2;
     aer.first_idx = 2;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 0, raft_get_commit_idx(r));
     raft_recv_appendentries_response(r, raft_get_node(r, 3), &aer);
@@ -3611,6 +3667,7 @@ void TestRaft_leader_recv_appendentries_response_do_not_increase_commit_idx_beca
     aer.success = 1;
     aer.current_idx = 3;
     aer.first_idx = 3;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 0, raft_get_commit_idx(r));
     raft_recv_appendentries_response(r, raft_get_node(r, 3), &aer);
@@ -3678,6 +3735,7 @@ void TestRaft_leader_recv_appendentries_response_jumps_to_lower_next_idx(
     aer.term = 2;
     aer.success = 0;
     aer.current_idx = 1;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 2, raft_node_get_next_idx(node));
 
@@ -3747,6 +3805,7 @@ void TestRaft_leader_recv_appendentries_response_decrements_to_lower_next_idx(
     aer.term = 2;
     aer.success = 0;
     aer.current_idx = 4;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 4, raft_node_get_next_idx(node));
 
@@ -3760,6 +3819,7 @@ void TestRaft_leader_recv_appendentries_response_decrements_to_lower_next_idx(
     aer.term = 2;
     aer.success = 0;
     aer.current_idx = 4;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 3, raft_node_get_next_idx(node));
 
@@ -3787,11 +3847,15 @@ void TestRaft_leader_recv_appendentries_response_retry_only_if_leader(CuTest * t
     raft_set_callbacks(r, &funcs, sender);
 
     /* I'm the leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 1);
+    raft_become_leader(r);
     raft_set_commit_idx(r, 0);
     /* the last applied idx will became 1, and then 2 */
     raft_set_last_applied_idx(r, 0);
+
+    /* consume appendentries messages sent by the raft_become_leader call */
+    CuAssertTrue(tc, NULL != sender_poll_msg_data(sender));
+    CuAssertTrue(tc, NULL != sender_poll_msg_data(sender));
 
     /* append entries - we need two */
     raft_entry_t ety = {};
@@ -3816,6 +3880,7 @@ void TestRaft_leader_recv_appendentries_response_retry_only_if_leader(CuTest * t
     aer.success = 1;
     aer.current_idx = 1;
     aer.first_idx = 1;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     CuAssertTrue(tc, RAFT_ERR_NOT_LEADER == raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer));
     CuAssertTrue(tc, NULL == sender_poll_msg_data(sender));
 }
@@ -3830,8 +3895,8 @@ void TestRaft_leader_recv_appendentries_response_without_node_fails(CuTest * tc)
     raft_add_node(r, NULL, 3, 0);
 
     /* I'm the leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 1);
+    raft_become_leader(r);
 
     /* receive mock success responses */
     msg_appendentries_response_t aer;
@@ -3840,6 +3905,7 @@ void TestRaft_leader_recv_appendentries_response_without_node_fails(CuTest * tc)
     aer.success = 1;
     aer.current_idx = 0;
     aer.first_idx = 0;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     CuAssertIntEquals(tc, -1, raft_recv_appendentries_response(r, NULL, &aer));
 }
 
@@ -3849,7 +3915,7 @@ void TestRaft_leader_recv_entry_resets_election_timeout(
     void *r = raft_new();
     raft_set_callbacks(r, &generic_funcs, NULL);
     raft_set_election_timeout(r, 1000);
-    raft_set_state(r, RAFT_STATE_LEADER);
+    raft_become_leader(r);
 
     __raft_clock += 900;
     raft_periodic(r);
@@ -3880,8 +3946,8 @@ void TestRaft_leader_recv_entry_is_committed_returns_0_if_not_committed(CuTest *
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
 
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 1);
+    raft_become_leader(r);
     raft_set_commit_idx(r, 0);
 
     /* entry message */
@@ -3913,8 +3979,8 @@ void TestRaft_leader_recv_entry_is_committed_returns_neg_1_if_invalidated(CuTest
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
 
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 1);
+    raft_become_leader(r);
     raft_set_commit_idx(r, 0);
 
     /* entry message */
@@ -3969,8 +4035,8 @@ void TestRaft_leader_recv_entry_fails_if_prevlogidx_less_than_commit(CuTest * tc
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
 
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 2);
+    raft_become_leader(r);
     raft_set_commit_idx(r, 0);
 
     /* entry message */
@@ -4025,9 +4091,12 @@ void TestRaft_leader_recv_entry_does_not_send_new_appendentries_to_slow_nodes(Cu
     void *sender = sender_new(NULL);
     raft_set_callbacks(r, &funcs, sender);
 
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 1);
+    raft_become_leader(r);
     raft_set_commit_idx(r, 0);
+
+    /* consume appendentries messages sent by the raft_become_leader call */
+    CuAssertTrue(tc, NULL != sender_poll_msg_data(sender));
 
     /* make the node slow */
     raft_node_set_next_idx(raft_get_node(r, 2), 1);
@@ -4073,8 +4142,8 @@ void TestRaft_leader_recv_appendentries_response_failure_does_not_set_node_nexti
     raft_set_callbacks(r, &funcs, sender);
 
     /* I'm the leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 1);
+    raft_become_leader(r);
     raft_set_commit_idx(r, 0);
 
     /* append entries */
@@ -4096,6 +4165,7 @@ void TestRaft_leader_recv_appendentries_response_failure_does_not_set_node_nexti
     aer.success = 0;
     aer.current_idx = 0;
     aer.first_idx = 0;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_node_t* p = raft_get_node(r, 2);
     raft_recv_appendentries_response(r, p, &aer);
     CuAssertTrue(tc, 1 == raft_node_get_next_idx(p));
@@ -4120,8 +4190,8 @@ void TestRaft_leader_recv_appendentries_response_increment_idx_of_node(
     raft_set_callbacks(r, &funcs, sender);
 
     /* I'm the leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 1);
+    raft_become_leader(r);
 
     raft_node_t* p = raft_get_node(r, 2);
     CuAssertTrue(tc, 1 == raft_node_get_next_idx(p));
@@ -4132,6 +4202,7 @@ void TestRaft_leader_recv_appendentries_response_increment_idx_of_node(
     aer.success = 1;
     aer.current_idx = 0;
     aer.first_idx = 0;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 1, raft_node_get_next_idx(p));
 }
@@ -4153,8 +4224,8 @@ void TestRaft_leader_recv_appendentries_response_drop_message_if_term_is_old(
     raft_set_callbacks(r, &funcs, sender);
 
     /* I'm the leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 2);
+    raft_become_leader(r);
 
     raft_node_t* p = raft_get_node(r, 2);
     CuAssertTrue(tc, 1 == raft_node_get_next_idx(p));
@@ -4165,6 +4236,7 @@ void TestRaft_leader_recv_appendentries_response_drop_message_if_term_is_old(
     aer.success = 1;
     aer.current_idx = 1;
     aer.first_idx = 1;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertTrue(tc, 1 == raft_node_get_next_idx(p));
 }
@@ -4185,8 +4257,8 @@ void TestRaft_leader_recv_appendentries_response_steps_down_if_term_is_newer(
     raft_set_callbacks(r, &funcs, sender);
 
     /* I'm the leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 2);
+    raft_become_leader(r);
 
     raft_node_t* p = raft_get_node(r, 2);
     CuAssertTrue(tc, 1 == raft_node_get_next_idx(p));
@@ -4197,9 +4269,49 @@ void TestRaft_leader_recv_appendentries_response_steps_down_if_term_is_newer(
     aer.success = 0;
     aer.current_idx = 2;
     aer.first_idx = 0;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertTrue(tc, 1 == raft_is_follower(r));
     CuAssertTrue(tc, -1 == raft_get_current_leader(r));
+}
+
+void TestRaft_leader_recv_appendentries_response_tracks_lease(
+    CuTest * tc)
+{
+    raft_cbs_t funcs = {
+        .log = NULL,
+        .get_time = __raft_get_time
+    };
+
+    void *sender = sender_new(NULL);
+    void *r = raft_new();
+    raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
+    raft_set_callbacks(r, &funcs, sender);
+
+    /* I'm the leader */
+    raft_set_current_term(r, 2);
+    raft_become_leader(r);
+
+    raft_node_t* p = raft_get_node(r, 2);
+    CuAssertTrue(tc, 0 == raft_node_get_lease(p));
+
+    /* receive newer lease */
+    msg_appendentries_response_t aer;
+    aer.term = 2;
+    aer.success = 0;
+    aer.current_idx = 2;
+    aer.first_idx = 0;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
+    raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
+    CuAssertIntEquals(tc, aer.lease, raft_node_get_lease(p));
+
+    /* receive older lease */
+    raft_time_t prev_lease = raft_node_get_lease(p);
+    CuAssertTrue(tc, prev_lease != __raft_clock);
+    aer.lease = __raft_clock;
+    raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
+    CuAssertIntEquals(tc, prev_lease, raft_node_get_lease(p));
 }
 
 void TestRaft_leader_recv_appendentries_steps_down_if_newer(
@@ -4214,8 +4326,8 @@ void TestRaft_leader_recv_appendentries_steps_down_if_newer(
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
 
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 5);
+    raft_become_leader(r);
     /* check that node 1 considers itself the leader */
     CuAssertTrue(tc, 1 == raft_is_leader(r));
     CuAssertTrue(tc, 1 == raft_get_current_leader(r));
@@ -4244,8 +4356,8 @@ void TestRaft_leader_recv_appendentries_steps_down_if_newer_term(
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
 
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 5);
+    raft_become_leader(r);
 
     memset(&ae, 0, sizeof(msg_appendentries_t));
     ae.term = 6;
@@ -4296,6 +4408,52 @@ void TestRaft_leader_sends_empty_appendentries_every_request_timeout(
     CuAssertTrue(tc, NULL != ae);
 }
 
+void TestRaft_leader_steps_down_if_unable_to_maintain_majority_leases(
+    CuTest * tc)
+{
+    void *r = raft_new();
+    raft_add_node(r, NULL, 1, 1);
+    raft_add_node(r, NULL, 2, 0);
+    raft_add_node(r, NULL, 3, 0);
+    raft_set_election_timeout(r, 1000);
+    raft_set_request_timeout(r, 500);
+    raft_set_lease_maintenance_grace(r, 100);
+    raft_set_callbacks(r, &generic_funcs, NULL);
+    CuAssertTrue(tc, 0 == raft_get_timeout_elapsed(r));
+
+    raft_set_current_term(r, 1);
+    raft_become_leader(r);
+
+    /* Before election timeout + lease maintenance grace has passed, do not step down. */
+    CuAssertTrue(tc, !raft_has_majority_leases(r));
+    /* Advance clock past election timoeut but before lease maintenance grace. */
+    __raft_clock += 1001;
+    CuAssertTrue(tc, 1000 < raft_get_timeout_elapsed(r));
+    CuAssertTrue(tc, raft_get_timeout_elapsed(r) < 1100);
+    raft_periodic(r);
+    CuAssertTrue(tc, raft_is_leader(r));
+
+    /* Do not step down if able to maintain majority leases. */
+    msg_appendentries_response_t aer;
+    aer.term = 1;
+    aer.success = 0;
+    aer.lease = __raft_clock + raft_get_election_timeout(r);
+    raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
+    CuAssertTrue(tc, raft_has_majority_leases(r));
+    /* Advance clock past lease maintenance grace. */
+    __raft_clock += 100;
+    CuAssertTrue(tc, __raft_clock < aer.lease);
+    raft_periodic(r);
+    CuAssertTrue(tc, raft_is_leader(r));
+
+    /* Step down if unable to maintain majority leases. */
+    __raft_clock += 2000;
+    CuAssertTrue(tc, aer.lease + raft_get_lease_maintenance_grace(r) < __raft_clock);
+    CuAssertTrue(tc, !raft_has_majority_leases(r));
+    raft_periodic(r);
+    CuAssertTrue(tc, !raft_is_leader(r));
+}
+
 /* TODO: If a server receives a request with a stale term number, it rejects the request. */
 #if 0
 void T_estRaft_leader_sends_appendentries_when_receive_entry_msg(CuTest * tc)
@@ -4320,6 +4478,7 @@ void TestRaft_leader_recv_prevote_responds_without_granting(CuTest * tc)
     raft_set_election_timeout(r, 1000);
     raft_set_request_timeout(r, 500);
     CuAssertTrue(tc, 0 == raft_get_timeout_elapsed(r));
+    wait_for_startup_lease(r);
 
     raft_become_candidate(r);
     raft_become_prevoted_candidate(r);
@@ -4400,6 +4559,7 @@ void TestRaft_leader_recv_requestvote_responds_without_granting(CuTest * tc)
     raft_set_election_timeout(r, 1000);
     raft_set_request_timeout(r, 500);
     CuAssertTrue(tc, 0 == raft_get_timeout_elapsed(r));
+    wait_for_startup_lease(r);
 
     raft_become_candidate(r);
     raft_become_prevoted_candidate(r);
@@ -4442,6 +4602,7 @@ void T_estRaft_leader_recv_requestvote_responds_with_granting_if_term_is_higher(
     raft_set_election_timeout(r, 1000);
     raft_set_request_timeout(r, 500);
     CuAssertTrue(tc, 0 == raft_get_timeout_elapsed(r));
+    wait_for_startup_lease(r);
 
     raft_election_start(r);
 
@@ -4480,8 +4641,8 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_after_v
     raft_set_callbacks(r, &funcs, &has_sufficient_logs_flag);
 
     /* I'm the leader */
-    raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 1);
+    raft_become_leader(r);
     raft_set_commit_idx(r, 0);
     raft_set_last_applied_idx(r, 0);
 
@@ -4498,7 +4659,8 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_after_v
     CuAssertIntEquals(tc, 0, raft_recv_entry(r, &ety, &etyr));
 
     msg_appendentries_response_t aer = {
-        .term = 1, .success = 1, .current_idx = 2, .first_idx = 0
+        .term = 1, .success = 1, .current_idx = 2, .first_idx = 0,
+        .lease = __raft_clock + raft_get_election_timeout(r)
     };
 
     /* node 3 responds so it has sufficient logs and will be promoted */

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -96,9 +96,20 @@ static int __raft_node_has_sufficient_logs(
     return 0;
 }
 
+static raft_time_t __raft_clock = 1000000;
+
+static raft_time_t __raft_get_time(
+    raft_server_t* raft,
+    void *udata
+    )
+{
+    return __raft_clock;
+}
+
 raft_cbs_t generic_funcs = {
     .persist_term = __raft_persist_term,
     .persist_vote = __raft_persist_vote,
+    .get_time = __raft_get_time
 };
 
 static int raft_append_entry(raft_server_t* me_, raft_entry_t* ety)
@@ -132,11 +143,13 @@ void TestRaft_server_get_my_node(CuTest * tc)
 void TestRaft_server_can_run_with_empty_configuration(CuTest * tc)
 {
     void *r = raft_new();
+    raft_set_callbacks(r, &generic_funcs, NULL);
     CuAssertIntEquals(tc, -1, raft_get_nodeid(r));
     raft_set_nodeid(r, 1);
     CuAssertIntEquals(tc, 1, raft_get_nodeid(r));
 
-    CuAssertIntEquals(tc, 0, raft_periodic(r, 1));
+    __raft_clock += 1;
+    CuAssertIntEquals(tc, 0, raft_periodic(r));
 
     msg_entry_response_t mr;
     msg_entry_t e[2] = { 0 };
@@ -158,7 +171,8 @@ void TestRaft_server_can_run_with_empty_configuration(CuTest * tc)
     CuAssertTrue(tc, 1 == aer.success);
     CuAssertTrue(tc, 2 == raft_get_log_count(r));
 
-    CuAssertIntEquals(tc, 0, raft_periodic(r, 1));
+    __raft_clock += 1;
+    CuAssertIntEquals(tc, 0, raft_periodic(r));
     CuAssertTrue(tc, 2 == raft_get_current_idx(r));
 }
 
@@ -372,6 +386,7 @@ void TestRaft_server_append_entry_user_can_set_data_buf(CuTest * tc)
     raft_cbs_t funcs = {
         .log_offer = __raft_logentry_offer,
         .persist_term = __raft_persist_term,
+        .get_time = __raft_get_time
     };
     char *buf = "aaa";
     raft_entry_t* kept;
@@ -494,6 +509,7 @@ void TestRaft_server_increment_lastApplied_when_lastApplied_lt_commitidx(
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
         .applylog = __raft_applylog,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -515,7 +531,8 @@ void TestRaft_server_increment_lastApplied_when_lastApplied_lt_commitidx(
     raft_set_commit_idx(r, 1);
 
     /* let time lapse */
-    raft_periodic(r, 1);
+    __raft_clock += 1;
+    raft_periodic(r);
     CuAssertIntEquals(tc, 1, raft_get_last_applied_idx(r));
 }
 
@@ -525,6 +542,7 @@ void TestRaft_user_applylog_error_propogates_to_periodic(
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
         .applylog = __raft_applylog_shutdown,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -546,7 +564,8 @@ void TestRaft_user_applylog_error_propogates_to_periodic(
     raft_set_commit_idx(r, 1);
 
     /* let time lapse */
-    CuAssertIntEquals(tc, RAFT_ERR_SHUTDOWN, raft_periodic(r, 1));
+    __raft_clock += 1;
+    CuAssertIntEquals(tc, RAFT_ERR_SHUTDOWN, raft_periodic(r));
     CuAssertIntEquals(tc, 1, raft_get_last_applied_idx(r));
 }
 
@@ -554,6 +573,7 @@ void TestRaft_server_apply_entry_increments_last_applied_idx(CuTest* tc)
 {
     raft_cbs_t funcs = {
         .applylog = __raft_applylog,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -571,26 +591,13 @@ void TestRaft_server_apply_entry_increments_last_applied_idx(CuTest* tc)
     CuAssertTrue(tc, 1 == raft_get_last_applied_idx(r));
 }
 
-void TestRaft_server_periodic_elapses_election_timeout(CuTest * tc)
-{
-    void *r = raft_new();
-    /* we don't want to set the timeout to zero */
-    raft_set_election_timeout(r, 1000);
-    CuAssertTrue(tc, 0 == raft_get_timeout_elapsed(r));
-
-    raft_periodic(r, 0);
-    CuAssertTrue(tc, 0 == raft_get_timeout_elapsed(r));
-
-    raft_periodic(r, 100);
-    CuAssertTrue(tc, 100 == raft_get_timeout_elapsed(r));
-}
-
 void TestRaft_server_election_timeout_does_not_promote_us_to_leader_if_there_is_are_more_than_1_nodes(CuTest * tc)
 {
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
         .persist_vote = __raft_persist_vote,
         .send_requestvote = __raft_send_requestvote,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -601,19 +608,26 @@ void TestRaft_server_election_timeout_does_not_promote_us_to_leader_if_there_is_
     raft_set_election_timeout(r, 1000);
 
     /* clock over (ie. 1000 + 1), causing new election */
-    raft_periodic(r, 1001);
+    __raft_clock += 1001;
+    raft_periodic(r);
 
     CuAssertTrue(tc, 0 == raft_is_leader(r));
 }
 
 void TestRaft_server_election_timeout_does_not_promote_us_to_leader_if_we_are_not_voting_node(CuTest * tc)
 {
+    raft_cbs_t funcs = {
+        .get_time = __raft_get_time
+    };
+
     void *r = raft_new();
+    raft_set_callbacks(r, &funcs, NULL);
     raft_add_non_voting_node(r, NULL, 1, 1);
     raft_set_election_timeout(r, 1000);
 
     /* clock over (ie. 1000 + 1), causing new election */
-    raft_periodic(r, 1001);
+    __raft_clock += 1001;
+    raft_periodic(r);
 
     CuAssertTrue(tc, 0 == raft_is_leader(r));
     CuAssertTrue(tc, 0 == raft_get_current_term(r));
@@ -621,25 +635,37 @@ void TestRaft_server_election_timeout_does_not_promote_us_to_leader_if_we_are_no
 
 void TestRaft_server_election_timeout_does_not_start_election_if_there_are_no_voting_nodes(CuTest * tc)
 {
+    raft_cbs_t funcs = {
+        .get_time = __raft_get_time
+    };
+
     void *r = raft_new();
+    raft_set_callbacks(r, &funcs, NULL);
     raft_add_non_voting_node(r, NULL, 1, 1);
     raft_add_non_voting_node(r, NULL, 2, 0);
     raft_set_election_timeout(r, 1000);
 
     /* clock over (ie. 1000 + 1), causing new election */
-    raft_periodic(r, 1001);
+    __raft_clock += 1001;
+    raft_periodic(r);
 
     CuAssertTrue(tc, 0 == raft_get_current_term(r));
 }
 
 void TestRaft_server_election_timeout_does_promote_us_to_leader_if_there_is_only_1_node(CuTest * tc)
 {
+    raft_cbs_t funcs = {
+        .get_time = __raft_get_time
+    };
+
     void *r = raft_new();
+    raft_set_callbacks(r, &funcs, NULL);
     raft_add_node(r, NULL, 1, 1);
     raft_set_election_timeout(r, 1000);
 
     /* clock over (ie. 1000 * 2 + 1), causing new election */
-    raft_periodic(r, 2001);
+    __raft_clock += 2001;
+    raft_periodic(r);
 
     CuAssertTrue(tc, 1 == raft_is_leader(r));
 }
@@ -648,6 +674,7 @@ void TestRaft_server_election_timeout_does_promote_us_to_leader_if_there_is_only
 {
     raft_cbs_t funcs = {
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -658,7 +685,8 @@ void TestRaft_server_election_timeout_does_promote_us_to_leader_if_there_is_only
     raft_set_election_timeout(r, 1000);
 
     /* clock over (ie. 2000 + 1), causing new election */
-    raft_periodic(r, 2001);
+    __raft_clock += 2001;
+    raft_periodic(r);
 
     CuAssertTrue(tc, 1 == raft_is_leader(r));
 }
@@ -666,6 +694,7 @@ void TestRaft_server_election_timeout_does_promote_us_to_leader_if_there_is_only
 void TestRaft_server_recv_entry_auto_commits_if_we_are_the_only_node(CuTest * tc)
 {
     void *r = raft_new();
+    raft_set_callbacks(r, &generic_funcs, NULL);
     raft_add_node(r, NULL, 1, 1);
     raft_set_election_timeout(r, 1000);
     raft_become_leader(r);
@@ -688,6 +717,7 @@ void TestRaft_server_recv_entry_fails_if_there_is_already_a_voting_change(CuTest
 {
     raft_cbs_t funcs = {
         .log_get_node_id = __raft_log_get_node_id,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -725,6 +755,7 @@ void TestRaft_server_recv_entry_succeeds_when_adding_a_removed_node(CuTest * tc)
 {
     raft_cbs_t funcs = {
         .log_get_node_id = __raft_log_get_node_id,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -821,13 +852,8 @@ void TestRaft_server_recv_requestvote_response_dont_increase_votes_for_me_when_n
     CuTest * tc
     )
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -847,13 +873,8 @@ void TestRaft_server_recv_requestvote_response_dont_increase_votes_for_me_when_t
     CuTest * tc
     )
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -877,6 +898,7 @@ void TestRaft_server_recv_prevote_response_increase_prevotes_for_me(
         .persist_vote = __raft_persist_vote,
         .send_requestvote = __raft_send_requestvote,
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -914,6 +936,7 @@ void TestRaft_server_recv_requestvote_response_increase_votes_for_me(
         .persist_vote = __raft_persist_vote,
         .send_requestvote = __raft_send_requestvote,
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -947,6 +970,7 @@ void TestRaft_server_recv_prevote_response_ignored_by_prevoted_candidate(
         .persist_term = __raft_persist_term,
         .persist_vote = __raft_persist_vote,
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -978,6 +1002,7 @@ void TestRaft_server_recv_requestvote_response_must_be_candidate_to_receive(
         .persist_term = __raft_persist_term,
         .persist_vote = __raft_persist_vote,
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -1003,13 +1028,8 @@ void TestRaft_server_recv_requestvote_reply_false_if_term_less_than_current_term
     CuTest * tc
     )
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     msg_requestvote_response_t rvr;
 
@@ -1035,6 +1055,7 @@ void TestRaft_leader_recv_requestvote_does_not_step_down(
         .persist_term = __raft_persist_term,
         .persist_vote = __raft_persist_vote,
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -1065,13 +1086,8 @@ void TestRaft_server_recv_requestvote_reply_true_if_term_greater_than_or_equal_t
     msg_requestvote_t rv;
     msg_requestvote_response_t rvr;
 
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -1101,7 +1117,8 @@ void TestRaft_server_recv_prevote_dont_grant_real_vote(
     raft_set_current_term(r, 1);
 
     raft_set_election_timeout(r, 1000);
-    raft_periodic(r, 900);
+    __raft_clock += 900;
+    raft_periodic(r);
 
     /* grant prevote but not real vote */
     memset(&rv, 0, sizeof(msg_requestvote_t));
@@ -1130,20 +1147,17 @@ void TestRaft_server_recv_requestvote_reset_timeout(
     msg_requestvote_t rv;
     msg_requestvote_response_t rvr;
 
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
     raft_set_current_term(r, 1);
 
     raft_set_election_timeout(r, 1000);
-    raft_periodic(r, 900);
+    __raft_clock += 900;
+    raft_periodic(r);
+    CuAssertIntEquals(tc, 900, raft_get_timeout_elapsed(r));
 
     memset(&rv, 0, sizeof(msg_requestvote_t));
     rv.term = 2;
@@ -1161,6 +1175,7 @@ void TestRaft_server_recv_requestvote_candidate_step_down_if_term_is_higher_than
         .persist_term = __raft_persist_term,
         .persist_vote = __raft_persist_vote,
         .send_requestvote = __raft_send_requestvote,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -1194,6 +1209,7 @@ void TestRaft_server_recv_requestvote_depends_on_candidate_id(
         .persist_term = __raft_persist_term,
         .persist_vote = __raft_persist_vote,
         .send_requestvote = __raft_send_requestvote,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -1225,13 +1241,8 @@ void TestRaft_server_recv_requestvote_dont_grant_vote_if_we_didnt_vote_for_this_
     CuTest * tc
     )
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 0, 0);
     raft_add_node(r, NULL, 1, 1);
@@ -1264,11 +1275,8 @@ void TestRaft_server_recv_requestvote_dont_grant_vote_if_we_didnt_vote_for_this_
  */
 void TestRaft_server_recv_prevote_ignore_if_master_is_fresh(CuTest * tc)
 {
-    raft_cbs_t funcs = { 0
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -1294,7 +1302,8 @@ void TestRaft_server_recv_prevote_ignore_if_master_is_fresh(CuTest * tc)
     CuAssertTrue(tc, 1 != rvr.vote_granted);
 
     /* After election timeout passed, the same prevote should be accepted */
-    raft_periodic(r, 1001);
+    __raft_clock += 1001;
+    raft_periodic(r);
     raft_recv_requestvote(r, raft_get_node(r, 3), &rv, &rvr);
     CuAssertTrue(tc, 1 == rvr.vote_granted);
 }
@@ -1305,11 +1314,8 @@ void TestRaft_server_recv_prevote_ignore_if_master_is_fresh(CuTest * tc)
  */
 void TestRaft_server_recv_requestvote_ignore_if_master_is_fresh(CuTest * tc)
 {
-    raft_cbs_t funcs = { 0
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -1334,19 +1340,16 @@ void TestRaft_server_recv_requestvote_ignore_if_master_is_fresh(CuTest * tc)
     CuAssertTrue(tc, 1 != rvr.vote_granted);
 
     /* After election timeout passed, the same requestvote should be accepted */
-    raft_periodic(r, 1001);
+    __raft_clock += 1001;
+    raft_periodic(r);
     raft_recv_requestvote(r, raft_get_node(r, 3), &rv, &rvr);
     CuAssertTrue(tc, 1 == rvr.vote_granted);
 }
 
 void TestRaft_server_recv_requestvote_ignore_local_membership(CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_vote = __raft_persist_vote,
-    };
-
     void* r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     /* empty local membership */
     msg_requestvote_t rv = {
@@ -1373,19 +1376,15 @@ void TestRaft_server_recv_requestvote_ignore_local_membership(CuTest * tc)
 void TestRaft_follower_becomes_follower_is_follower(CuTest * tc)
 {
     void *r = raft_new();
+    raft_set_callbacks(r, &generic_funcs, NULL);
     raft_become_follower(r);
     CuAssertTrue(tc, raft_is_follower(r));
 }
 
 void TestRaft_follower_becomes_follower_does_not_clear_voted_for(CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
 
@@ -1399,12 +1398,8 @@ void TestRaft_follower_becomes_follower_does_not_clear_voted_for(CuTest * tc)
 void TestRaft_follower_recv_appendentries_reply_false_if_term_less_than_currentterm(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -1428,12 +1423,8 @@ void TestRaft_follower_recv_appendentries_reply_false_if_term_less_than_currentt
 
 void TestRaft_follower_recv_appendentries_does_not_need_node(CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -1448,12 +1439,8 @@ void TestRaft_follower_recv_appendentries_does_not_need_node(CuTest * tc)
 void TestRaft_follower_recv_appendentries_updates_currentterm_if_term_gt_currentterm(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     msg_appendentries_t ae;
     msg_appendentries_response_t aer;
@@ -1484,12 +1471,8 @@ void TestRaft_follower_recv_appendentries_updates_currentterm_if_term_gt_current
 void TestRaft_follower_recv_appendentries_does_not_log_if_no_entries_are_specified(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     msg_appendentries_t ae;
     msg_appendentries_response_t aer;
@@ -1516,12 +1499,9 @@ void TestRaft_follower_recv_appendentries_does_not_log_if_no_entries_are_specifi
 
 void TestRaft_follower_recv_appendentries_increases_log(CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
     raft_entry_t *log;
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     msg_appendentries_t ae;
     msg_entry_t ety = {};
@@ -1564,12 +1544,8 @@ void TestRaft_follower_recv_appendentries_increases_log(CuTest * tc)
 void TestRaft_follower_recv_appendentries_reply_false_if_doesnt_have_log_at_prev_log_idx_which_matches_prev_log_term(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     msg_entry_t ety = {};
     char *str = "aaa";
@@ -1651,12 +1627,8 @@ static raft_entry_t* __create_mock_entries_for_conflict_tests(
 void TestRaft_follower_recv_appendentries_delete_entries_if_conflict_with_new_entries_via_prev_log_idx(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     msg_appendentries_t ae;
     msg_appendentries_response_t aer;
@@ -1701,12 +1673,8 @@ void TestRaft_follower_recv_appendentries_delete_entries_if_conflict_with_new_en
 void TestRaft_follower_recv_appendentries_delete_entries_if_conflict_with_new_entries_via_prev_log_idx_at_idx_0(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     msg_appendentries_t ae;
     msg_appendentries_response_t aer;
@@ -1747,12 +1715,8 @@ void TestRaft_follower_recv_appendentries_delete_entries_if_conflict_with_new_en
 void TestRaft_follower_recv_appendentries_delete_entries_if_conflict_with_new_entries_greater_than_prev_log_idx(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     msg_appendentries_t ae;
     msg_appendentries_response_t aer;
@@ -1790,12 +1754,8 @@ void TestRaft_follower_recv_appendentries_delete_entries_if_conflict_with_new_en
 void TestRaft_follower_recv_appendentries_add_new_entries_not_already_in_log(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -1824,12 +1784,8 @@ void TestRaft_follower_recv_appendentries_add_new_entries_not_already_in_log(
 void TestRaft_follower_recv_appendentries_does_not_add_dupe_entries_already_in_log(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -1917,6 +1873,7 @@ void TestRaft_follower_recv_appendentries_partial_failures(
         .persist_term = __raft_persist_term,
         .log_offer = __raft_log_offer_error,
         .log_pop = __raft_log_pop_error,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -1999,12 +1956,8 @@ void TestRaft_follower_recv_appendentries_partial_failures(
 void TestRaft_follower_recv_appendentries_set_commitidx_to_prevLogIdx(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -2048,12 +2001,8 @@ void TestRaft_follower_recv_appendentries_set_commitidx_to_prevLogIdx(
 void TestRaft_follower_recv_appendentries_set_commitidx_to_LeaderCommit(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -2097,12 +2046,8 @@ void TestRaft_follower_recv_appendentries_set_commitidx_to_LeaderCommit(
 void TestRaft_follower_recv_appendentries_failure_includes_current_idx(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -2145,6 +2090,7 @@ void TestRaft_follower_becomes_candidate_when_election_timeout_occurs(
         .persist_term = __raft_persist_term,
         .persist_vote = __raft_persist_vote,
         .send_requestvote = __raft_send_requestvote,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -2157,7 +2103,8 @@ void TestRaft_follower_becomes_candidate_when_election_timeout_occurs(
     raft_add_node(r, NULL, 2, 0);
 
     /*  max election timeout have passed */
-    raft_periodic(r, max_election_timeout(1000) + 1);
+    __raft_clock += max_election_timeout(1000) + 1;
+    raft_periodic(r);
 
     /* is a candidate now */
     CuAssertTrue(tc, 1 == raft_is_candidate(r));
@@ -2220,13 +2167,8 @@ void TestRaft_follower_dont_grant_vote_if_candidate_has_a_less_complete_log(
     msg_requestvote_t rv;
     msg_requestvote_response_t rvr;
 
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -2270,12 +2212,8 @@ void TestRaft_follower_dont_grant_vote_if_candidate_has_a_less_complete_log(
 void TestRaft_follower_recv_appendentries_heartbeat_does_not_overwrite_logs(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -2334,12 +2272,8 @@ void TestRaft_follower_recv_appendentries_heartbeat_does_not_overwrite_logs(
 void TestRaft_follower_recv_appendentries_does_not_deleted_commited_entries(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -2432,13 +2366,8 @@ void TestRaft_follower_recv_appendentries_does_not_deleted_commited_entries(
 
 void TestRaft_candidate_becomes_candidate_is_candidate(CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
 
@@ -2449,13 +2378,8 @@ void TestRaft_candidate_becomes_candidate_is_candidate(CuTest * tc)
 /* Candidate 5.2 */
 void TestRaft_follower_becoming_candidate_increments_current_term(CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
 
@@ -2469,13 +2393,8 @@ void TestRaft_follower_becoming_candidate_increments_current_term(CuTest * tc)
 /* Candidate 5.2 */
 void TestRaft_follower_becoming_candidate_votes_for_self(CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -2489,20 +2408,16 @@ void TestRaft_follower_becoming_candidate_votes_for_self(CuTest * tc)
 /* Candidate 5.2 */
 void TestRaft_follower_becoming_candidate_resets_election_timeout(CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
 
     raft_set_election_timeout(r, 1000);
     CuAssertTrue(tc, 0 == raft_get_timeout_elapsed(r));
 
-    raft_periodic(r, 900);
+    __raft_clock += 900;
+    raft_periodic(r);
     CuAssertTrue(tc, 900 == raft_get_timeout_elapsed(r));
 
     raft_become_candidate(r);
@@ -2513,19 +2428,16 @@ void TestRaft_follower_becoming_candidate_resets_election_timeout(CuTest * tc)
 void TestRaft_follower_recv_appendentries_resets_election_timeout(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_set_election_timeout(r, 1000);
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 1);
 
-    raft_periodic(r, 900);
+    __raft_clock += 900;
+    raft_periodic(r);
+    CuAssertIntEquals(tc, 900, raft_get_timeout_elapsed(r));
 
     msg_appendentries_t ae;
     msg_appendentries_response_t aer;
@@ -2544,6 +2456,7 @@ void TestRaft_follower_becoming_candidate_requests_votes_from_other_servers(
         .persist_term = __raft_persist_term,
         .persist_vote = __raft_persist_vote,
         .send_requestvote = sender_requestvote,
+        .get_time = __raft_get_time
     };
     msg_requestvote_t* rv;
 
@@ -2594,6 +2507,7 @@ void TestRaft_candidate_election_timeout_and_no_leader_results_in_new_election(
         .persist_term = __raft_persist_term,
         .persist_vote = __raft_persist_vote,
         .send_requestvote = __raft_send_requestvote,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -2614,7 +2528,8 @@ void TestRaft_candidate_election_timeout_and_no_leader_results_in_new_election(
     CuAssertTrue(tc, 1 == raft_get_current_term(r));
 
     /* clock over (ie. max election timeout + 1), causing new election */
-    raft_periodic(r, max_election_timeout(1000) + 1);
+    __raft_clock += max_election_timeout(1000) + 1;
+    raft_periodic(r);
     CuAssertTrue(tc, raft_is_candidate(r));
 
     /*  receiving this vote gives the server majority */
@@ -2632,6 +2547,7 @@ void TestRaft_candidate_receives_majority_of_votes_becomes_leader(CuTest * tc)
         .persist_vote = __raft_persist_vote,
         .send_requestvote = __raft_send_requestvote,
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -2669,13 +2585,8 @@ void TestRaft_candidate_receives_majority_of_votes_becomes_leader(CuTest * tc)
 void TestRaft_candidate_will_not_respond_to_voterequest_if_it_has_already_voted(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     msg_requestvote_t rv;
     msg_requestvote_response_t rvr;
@@ -2700,6 +2611,7 @@ void TestRaft_candidate_requestvote_includes_logidx(CuTest * tc)
         .log              = NULL,
         .persist_term = __raft_persist_term,
         .persist_vote = __raft_persist_vote,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -2735,13 +2647,8 @@ void TestRaft_candidate_requestvote_includes_logidx(CuTest * tc)
 void TestRaft_candidate_recv_requestvote_response_becomes_follower_if_current_term_is_less_than_term(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -2865,13 +2772,8 @@ void TestRaft_candidate_recv_requestvote_may_grant_vote(
 void TestRaft_candidate_recv_appendentries_frm_leader_results_in_follower(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -2903,6 +2805,7 @@ void TestRaft_candidate_recv_appendentries_from_same_term_results_in_step_down(
         .persist_term = __raft_persist_term,
         .persist_vote = __raft_persist_vote,
         .send_requestvote = __raft_send_requestvote,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -2937,6 +2840,7 @@ void TestRaft_prevoted_candidate_recv_appendentries_from_same_term_results_in_st
         .persist_term = __raft_persist_term,
         .persist_vote = __raft_persist_vote,
         .send_requestvote = __raft_send_requestvote,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -2979,19 +2883,15 @@ void TestRaft_prevoted_candidate_recv_appendentries_from_same_term_results_in_st
 void TestRaft_leader_becomes_leader_is_leader(CuTest * tc)
 {
     void *r = raft_new();
+    raft_set_callbacks(r, &generic_funcs, NULL);
     raft_become_leader(r);
     CuAssertTrue(tc, raft_is_leader(r));
 }
 
 void TestRaft_leader_becomes_leader_does_not_clear_voted_for(CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_vote(r, raft_get_node(r, 1));
@@ -3005,6 +2905,7 @@ void TestRaft_leader_when_becomes_leader_all_nodes_have_nextidx_equal_to_lastlog
 {
     raft_cbs_t funcs = {
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -3033,7 +2934,8 @@ void TestRaft_leader_when_it_becomes_a_leader_sends_empty_appendentries(
 {
     raft_cbs_t funcs = {
         .send_appendentries = sender_appendentries,
-        .log                = NULL
+        .log = NULL,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -3060,6 +2962,7 @@ void TestRaft_leader_responds_to_entry_msg_when_entry_is_committed(CuTest * tc)
 {
     raft_cbs_t funcs = {
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -3093,6 +2996,7 @@ void TestRaft_non_leader_recv_entry_msg_fails(CuTest * tc)
     msg_entry_response_t cr;
 
     void *r = raft_new();
+    raft_set_callbacks(r, &generic_funcs, NULL);
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
 
@@ -3115,7 +3019,8 @@ void TestRaft_leader_sends_appendentries_with_NextIdx_when_PrevIdx_gt_NextIdx(
 {
     raft_cbs_t funcs = {
         .send_appendentries = sender_appendentries,
-        .log                = NULL
+        .log = NULL,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -3152,7 +3057,8 @@ void TestRaft_leader_sends_appendentries_with_leader_commit(
 {
     raft_cbs_t funcs = {
         .send_appendentries = sender_appendentries,
-        .log                = NULL
+        .log = NULL,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -3190,7 +3096,8 @@ void TestRaft_leader_sends_appendentries_with_prevLogIdx(
 {
     raft_cbs_t funcs = {
         .send_appendentries = sender_appendentries,
-        .log                = NULL
+        .log = NULL,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -3241,7 +3148,8 @@ void TestRaft_leader_sends_appendentries_when_node_has_next_idx_of_0(
 {
     raft_cbs_t funcs = {
         .send_appendentries = sender_appendentries,
-        .log                = NULL
+        .log = NULL,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -3279,7 +3187,8 @@ void TestRaft_leader_retries_appendentries_with_decremented_NextIdx_log_inconsis
 {
     raft_cbs_t funcs = {
         .send_appendentries = sender_appendentries,
-        .log                = NULL
+        .log = NULL,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -3305,6 +3214,7 @@ void TestRaft_leader_append_entry_to_log_increases_idxno(CuTest * tc)
 {
     raft_cbs_t funcs = {
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -3363,8 +3273,9 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_when_majori
     raft_cbs_t funcs = {
         .applylog = __raft_applylog,
         .persist_term = __raft_persist_term,
-        .send_appendentries          = sender_appendentries,
-        .log                         = NULL
+        .send_appendentries = sender_appendentries,
+        .log = NULL,
+        .get_time = __raft_get_time
     };
     msg_appendentries_response_t aer;
 
@@ -3413,7 +3324,8 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_when_majori
     raft_recv_appendentries_response(r, raft_get_node(r, 3), &aer);
     /* leader will now have majority followers who have appended this log */
     CuAssertIntEquals(tc, 1, raft_get_commit_idx(r));
-    raft_periodic(r, 1);
+    __raft_clock += 1;
+    raft_periodic(r);
     CuAssertIntEquals(tc, 1, raft_get_last_applied_idx(r));
 
     /* SECOND entry log application */
@@ -3431,7 +3343,8 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_when_majori
     raft_recv_appendentries_response(r, raft_get_node(r, 3), &aer);
     /* leader will now have majority followers who have appended this log */
     CuAssertIntEquals(tc, 2, raft_get_commit_idx(r));
-    raft_periodic(r, 1);
+    __raft_clock += 1;
+    raft_periodic(r);
     CuAssertIntEquals(tc, 2, raft_get_last_applied_idx(r));
 }
 
@@ -3442,7 +3355,8 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_for_nod
         .applylog = __raft_applylog,
         .persist_term = __raft_persist_term,
         .node_has_sufficient_logs = __raft_node_has_sufficient_logs,
-        .log                         = NULL
+        .log = NULL,
+        .get_time = __raft_get_time
     };
     msg_appendentries_response_t aer;
 
@@ -3497,8 +3411,9 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_using_votin
     raft_cbs_t funcs = {
         .applylog = __raft_applylog,
         .persist_term = __raft_persist_term,
-        .send_appendentries          = sender_appendentries,
-        .log                         = NULL
+        .send_appendentries = sender_appendentries,
+        .log = NULL,
+        .get_time = __raft_get_time
     };
     msg_appendentries_response_t aer;
 
@@ -3540,7 +3455,8 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_using_votin
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 1, raft_get_commit_idx(r));
     /* leader will now have majority followers who have appended this log */
-    raft_periodic(r, 1);
+    __raft_clock += 1;
+    raft_periodic(r);
     CuAssertIntEquals(tc, 1, raft_get_last_applied_idx(r));
 }
 
@@ -3549,8 +3465,9 @@ void TestRaft_leader_recv_appendentries_response_duplicate_does_not_decrement_ma
 {
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
-        .send_appendentries          = sender_appendentries,
-        .log                         = NULL
+        .send_appendentries = sender_appendentries,
+        .log = NULL,
+        .get_time = __raft_get_time
     };
     msg_appendentries_response_t aer;
 
@@ -3613,8 +3530,9 @@ void TestRaft_leader_recv_appendentries_response_do_not_increase_commit_idx_beca
     raft_cbs_t funcs = {
         .applylog = __raft_applylog,
         .persist_term = __raft_persist_term,
-        .send_appendentries          = sender_appendentries,
-        .log                         = NULL
+        .send_appendentries = sender_appendentries,
+        .log = NULL,
+        .get_time = __raft_get_time
     };
     msg_appendentries_response_t aer;
 
@@ -3662,7 +3580,8 @@ void TestRaft_leader_recv_appendentries_response_do_not_increase_commit_idx_beca
     CuAssertIntEquals(tc, 0, raft_get_commit_idx(r));
     raft_recv_appendentries_response(r, raft_get_node(r, 3), &aer);
     CuAssertIntEquals(tc, 0, raft_get_commit_idx(r));
-    raft_periodic(r, 1);
+    __raft_clock += 1;
+    raft_periodic(r);
     CuAssertIntEquals(tc, 0, raft_get_last_applied_idx(r));
 
     /* SECOND entry log application */
@@ -3679,7 +3598,8 @@ void TestRaft_leader_recv_appendentries_response_do_not_increase_commit_idx_beca
     CuAssertIntEquals(tc, 0, raft_get_commit_idx(r));
     raft_recv_appendentries_response(r, raft_get_node(r, 3), &aer);
     CuAssertIntEquals(tc, 0, raft_get_commit_idx(r));
-    raft_periodic(r, 1);
+    __raft_clock += 1;
+    raft_periodic(r);
     CuAssertIntEquals(tc, 0, raft_get_last_applied_idx(r));
 
     /* THIRD entry log application */
@@ -3695,7 +3615,8 @@ void TestRaft_leader_recv_appendentries_response_do_not_increase_commit_idx_beca
     CuAssertIntEquals(tc, 0, raft_get_commit_idx(r));
     raft_recv_appendentries_response(r, raft_get_node(r, 3), &aer);
     CuAssertIntEquals(tc, 3, raft_get_commit_idx(r));
-    raft_periodic(r, 1);
+    __raft_clock += 1;
+    raft_periodic(r);
     CuAssertIntEquals(tc, 3, raft_get_last_applied_idx(r));
 }
 
@@ -3704,8 +3625,9 @@ void TestRaft_leader_recv_appendentries_response_jumps_to_lower_next_idx(
 {
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
-        .send_appendentries          = sender_appendentries,
-        .log                         = NULL
+        .send_appendentries = sender_appendentries,
+        .log = NULL,
+        .get_time = __raft_get_time
     };
     msg_appendentries_response_t aer;
 
@@ -3772,8 +3694,9 @@ void TestRaft_leader_recv_appendentries_response_decrements_to_lower_next_idx(
 {
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
-        .send_appendentries          = sender_appendentries,
-        .log                         = NULL
+        .send_appendentries = sender_appendentries,
+        .log = NULL,
+        .get_time = __raft_get_time
     };
     msg_appendentries_response_t aer;
 
@@ -3852,7 +3775,8 @@ void TestRaft_leader_recv_appendentries_response_retry_only_if_leader(CuTest * t
 {
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
-        .send_appendentries          = sender_appendentries,
+        .send_appendentries = sender_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -3898,12 +3822,8 @@ void TestRaft_leader_recv_appendentries_response_retry_only_if_leader(CuTest * t
 
 void TestRaft_leader_recv_appendentries_response_without_node_fails(CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -3927,10 +3847,12 @@ void TestRaft_leader_recv_entry_resets_election_timeout(
     CuTest * tc)
 {
     void *r = raft_new();
+    raft_set_callbacks(r, &generic_funcs, NULL);
     raft_set_election_timeout(r, 1000);
     raft_set_state(r, RAFT_STATE_LEADER);
 
-    raft_periodic(r, 900);
+    __raft_clock += 900;
+    raft_periodic(r);
 
     /* entry message */
     msg_entry_t mety = {};
@@ -3949,6 +3871,7 @@ void TestRaft_leader_recv_entry_is_committed_returns_0_if_not_committed(CuTest *
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -3981,6 +3904,7 @@ void TestRaft_leader_recv_entry_is_committed_returns_neg_1_if_invalidated(CuTest
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -4036,6 +3960,7 @@ void TestRaft_leader_recv_entry_fails_if_prevlogidx_less_than_commit(CuTest * tc
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -4093,7 +4018,8 @@ void TestRaft_leader_recv_entry_does_not_send_new_appendentries_to_slow_nodes(Cu
 
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
-        .send_appendentries          = sender_appendentries,
+        .send_appendentries = sender_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -4135,8 +4061,9 @@ void TestRaft_leader_recv_appendentries_response_failure_does_not_set_node_nexti
 {
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
-        .send_appendentries          = sender_appendentries,
-        .log                         = NULL
+        .send_appendentries = sender_appendentries,
+        .log = NULL,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -4181,8 +4108,9 @@ void TestRaft_leader_recv_appendentries_response_increment_idx_of_node(
 {
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
-        .send_appendentries          = sender_appendentries,
-        .log                         = NULL
+        .send_appendentries = sender_appendentries,
+        .log = NULL,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -4213,8 +4141,9 @@ void TestRaft_leader_recv_appendentries_response_drop_message_if_term_is_old(
 {
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
-        .send_appendentries          = sender_appendentries,
-        .log                         = NULL
+        .send_appendentries = sender_appendentries,
+        .log = NULL,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -4244,8 +4173,9 @@ void TestRaft_leader_recv_appendentries_response_steps_down_if_term_is_newer(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .send_appendentries          = sender_appendentries,
-        .log                         = NULL
+        .send_appendentries = sender_appendentries,
+        .log = NULL,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -4275,12 +4205,8 @@ void TestRaft_leader_recv_appendentries_response_steps_down_if_term_is_newer(
 void TestRaft_leader_recv_appendentries_steps_down_if_newer(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     msg_appendentries_t ae;
     msg_appendentries_response_t aer;
@@ -4309,12 +4235,8 @@ void TestRaft_leader_recv_appendentries_steps_down_if_newer(
 void TestRaft_leader_recv_appendentries_steps_down_if_newer_term(
     CuTest * tc)
 {
-    raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-    };
-
     void *r = raft_new();
-    raft_set_callbacks(r, &funcs, NULL);
+    raft_set_callbacks(r, &generic_funcs, NULL);
 
     msg_appendentries_t ae;
     msg_appendentries_response_t aer;
@@ -4339,7 +4261,8 @@ void TestRaft_leader_sends_empty_appendentries_every_request_timeout(
 {
     raft_cbs_t funcs = {
         .send_appendentries = sender_appendentries,
-        .log                = NULL
+        .log = NULL,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -4367,7 +4290,8 @@ void TestRaft_leader_sends_empty_appendentries_every_request_timeout(
     CuAssertTrue(tc, NULL == ae);
 
     /* force request timeout */
-    raft_periodic(r, 501);
+    __raft_clock += 501;
+    raft_periodic(r);
     ae = sender_poll_msg_data(sender);
     CuAssertTrue(tc, NULL != ae);
 }
@@ -4384,6 +4308,7 @@ void TestRaft_leader_recv_prevote_responds_without_granting(CuTest * tc)
         .persist_term = __raft_persist_term,
         .send_requestvote = __raft_send_requestvote,
         .send_appendentries = sender_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -4463,6 +4388,7 @@ void TestRaft_leader_recv_requestvote_responds_without_granting(CuTest * tc)
         .persist_term = __raft_persist_term,
         .send_requestvote = __raft_send_requestvote,
         .send_appendentries = sender_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -4504,6 +4430,7 @@ void T_estRaft_leader_recv_requestvote_responds_with_granting_if_term_is_higher(
         .persist_term = __raft_persist_term,
         .send_requestvote = __raft_send_requestvote,
         .send_appendentries = sender_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *sender = sender_new(NULL);
@@ -4542,7 +4469,8 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_after_v
         .persist_term = __raft_persist_term,
         .node_has_sufficient_logs = __raft_node_has_sufficient_logs,
         .log_get_node_id = __raft_log_get_node_id,
-        .log_offer = __raft_log_offer
+        .log_offer = __raft_log_offer,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -84,6 +84,16 @@ static int __raft_send_installsnapshot_capture(raft_server_t* raft,
     return 0;
 }
 
+static raft_time_t __raft_clock = 1000000;
+
+static raft_time_t __raft_get_time(
+    raft_server_t* raft,
+    void *udata
+    )
+{
+    return 0;
+}
+
 /* static raft_cbs_t generic_funcs = { */
 /*     .persist_term = __raft_persist_term, */
 /*     .persist_vote = __raft_persist_vote, */
@@ -107,6 +117,7 @@ void TestRaft_leader_begin_snapshot_fails_if_no_logs_to_compact(CuTest * tc)
 {
     raft_cbs_t funcs = {
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -145,6 +156,7 @@ void TestRaft_leader_will_not_apply_entry_if_snapshot_is_in_progress(CuTest * tc
 {
     raft_cbs_t funcs = {
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -183,6 +195,7 @@ void TestRaft_leader_snapshot_end_fails_if_snapshot_not_in_progress(CuTest * tc)
 {
     raft_cbs_t funcs = {
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -202,7 +215,8 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted(CuTest * tc)
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
         .send_appendentries = __raft_send_appendentries,
-        .send_installsnapshot = __raft_send_installsnapshot
+        .send_installsnapshot = __raft_send_installsnapshot,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -239,7 +253,8 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted(CuTest * tc)
     CuAssertIntEquals(tc, 1, raft_get_log_count(r));
     CuAssertIntEquals(tc, 1, raft_get_commit_idx(r));
     CuAssertIntEquals(tc, 1, raft_get_last_applied_idx(r));
-    CuAssertIntEquals(tc, 0, raft_periodic(r, 1000));
+    __raft_clock += 1000;
+    CuAssertIntEquals(tc, 0, raft_periodic(r));
 }
 
 void TestRaft_leader_snapshot_end_succeeds_if_log_compacted2(CuTest * tc)
@@ -247,7 +262,8 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted2(CuTest * tc)
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
         .send_appendentries = __raft_send_appendentries,
-        .send_installsnapshot = __raft_send_installsnapshot
+        .send_installsnapshot = __raft_send_installsnapshot,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -286,13 +302,15 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted2(CuTest * tc)
     CuAssertIntEquals(tc, 1, raft_get_log_count(r));
     CuAssertIntEquals(tc, 2, raft_get_commit_idx(r));
     CuAssertIntEquals(tc, 2, raft_get_last_applied_idx(r));
-    CuAssertIntEquals(tc, 0, raft_periodic(r, 1000));
+    __raft_clock += 1000;
+    CuAssertIntEquals(tc, 0, raft_periodic(r));
 }
 
 void TestRaft_joinee_needs_to_get_snapshot(CuTest * tc)
 {
     raft_cbs_t funcs = {
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -330,6 +348,7 @@ void TestRaft_joinee_needs_to_get_snapshot(CuTest * tc)
 void TestRaft_follower_load_from_snapshot(CuTest * tc)
 {
     raft_cbs_t funcs = {
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -356,7 +375,8 @@ void TestRaft_follower_load_from_snapshot(CuTest * tc)
     CuAssertIntEquals(tc, 5, raft_get_commit_idx(r));
     CuAssertIntEquals(tc, 5, raft_get_last_applied_idx(r));
 
-    CuAssertIntEquals(tc, 0, raft_periodic(r, 1000));
+    __raft_clock += 1000;
+    CuAssertIntEquals(tc, 0, raft_periodic(r));
 
     /* committed idx means snapshot was unnecessary */
     ety.id = 6;
@@ -371,6 +391,7 @@ void TestRaft_follower_load_from_snapshot(CuTest * tc)
 void TestRaft_follower_load_from_snapshot_fails_if_already_loaded(CuTest * tc)
 {
     raft_cbs_t funcs = {
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();
@@ -397,6 +418,7 @@ void TestRaft_leader_sends_appendentries_when_node_next_index_was_compacted(CuTe
     raft_cbs_t funcs = {
         .send_appendentries = __raft_send_appendentries,
         .send_installsnapshot = __raft_send_installsnapshot_capture,
+        .get_time = __raft_get_time
     };
 
     msg_installsnapshot_t is;
@@ -453,6 +475,7 @@ void TestRaft_recv_entry_fails_if_snapshot_in_progress(CuTest* tc)
 {
     raft_cbs_t funcs = {
         .send_appendentries = __raft_send_appendentries,
+        .get_time = __raft_get_time
     };
 
     void *r = raft_new();


### PR DESCRIPTION
Currently, the library implements the election timer using the time duration parameter msec_elapsed of raft_periodic. While this avoids introducing clocks into the library and eases testing, reasoning precisely about time becomes harder. For example, consider the following events on a follower:

    Time  Event
      10  raft_periodic(...)
      15  raft_recv_appendentries(...)
            // This call sets timeout_elapsed to 0.
      20  raft_periodic(..., 20 - 10 /* msec_elapsed */)
            // The actual time elapsed since the
            // raft_recv_appendentries call is 20 - 15,
            // rather than 20 - 10.

The election timer is _effectively_ reset by the raft_periodic call at time 10, instead of the raft_recv_appendentries call at time 15. When we implement leadership leases based on election timers, the lease granted by this follower effectively expires 5-millisecond earlier than expected!

One can argue that if the user calls raft_periodic with a period way smaller than the election timeout, the 5-millisecond difference may not matter to the election timeout or the lease. For certain users it may be hard to guarantee that the period will always be small.

Because leadership leases affect not only aliveness but also safety (i.e., a read sees the latest applied writes), it seems better to simplify the reasoning by introducing a user-implemented clock and base election timers on timestamps, rather than durations. The example will become:

    Time  Event
      10  raft_periodic(...)
            // The time of this call no longer affects the
            // following calls.
      15  raft_recv_appendentries(...)
            // This call gets the current time 15 and saves it.
      20  raft_periodic(...)
            // This call gets the current time 20 and computes
            // the time elapsed with 20 - 15.

This patch consists of the following changes:

  - Introduce raft_time_t and raft_cbs_t.get_time.

  - Remove the msec_elapsed parameter of raft_periodic.

  - Change raft_server_private_t.timeout_elapsed to the time the election timer begins.
        - Initialize this timestamp in raft_set_callbacks.

  - Update the tests to supply __raft_get_time, which uses a mock clock, __raft_clock.