### PR TITLE
Reject request vote if self is leader

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -607,8 +607,8 @@ int raft_recv_requestvote(raft_server_t* me_,
         node = raft_get_node(me_, vr->candidate_id);
 
     /* Reject request if we have a leader */
-    if (me->leader_id != -1 && me->leader_id != vr->candidate_id &&
-        me->timeout_elapsed < me->election_timeout)
+    if ((me->leader_id != -1 && me->leader_id != vr->candidate_id &&
+        me->timeout_elapsed < me->election_timeout) || me->state == RAFT_STATE_LEADER)
     {
         r->vote_granted = 0;
         goto done;


### PR DESCRIPTION
# Description
If the request_timeout is misconfigured to be equal to or greater than election_timeout, it can lead to a situation where the leader receives a request vote from a precandidate, triggering an assertion in the code.
https://github.com/daos-stack/raft/blob/3d20556a08fc21deb6899104ad817d0a6e8e7af4/src/raft_server.c#L633

However, this issue may not be a critical error because the configuration of the Raft protocol is not normal.

# How to trigger
Config the request_timeout to equal election_timeout. When the leader calls raft_periodic, it may cause `me->timeout_elapsed` to be equal to `me->election_timeout`, which can cause the condition check in the code to fail, and can further trigger the above assertion:
https://github.com/daos-stack/raft/blob/3d20556a08fc21deb6899104ad817d0a6e8e7af4/src/raft_server.c#L610-L611
