### PR TITLE
DAOS-12944 server: Track leadership leases

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -200,6 +200,9 @@ typedef struct
     /** true if follower contained entry matching prevLogidx and prevLogTerm */
     int success;
 
+    /** lease expiration time */
+    raft_time_t lease;
+
     /* Non-Raft fields follow: */
     /* Having the following fields allows us to do less book keeping in
      * regards to full fledged RPC */
@@ -236,6 +239,9 @@ typedef struct
 
     /** True if the snapshot has been fully received */
     int complete;
+
+    /** lease expiration time */
+    raft_time_t lease;
 } msg_installsnapshot_response_t;
 
 typedef void* raft_server_t;
@@ -602,6 +608,13 @@ void raft_set_election_timeout(raft_server_t* me, int msec);
  * @param[in] msec Request timeout in milliseconds */
 void raft_set_request_timeout(raft_server_t* me, int msec);
 
+/** Set lease maintenance grace.
+ * The amount of time granted to a leader to reestablish an expired lease
+ * before the leader is concluded to be unable to maintain the lease (a leader
+ * who is unable to maintain leases from a majority steps down voluntarily)
+ * @param[in] msec Lease mainenace grace in milliseconds */
+void raft_set_lease_maintenance_grace(raft_server_t* me, int msec);
+
 /** Process events that are dependent on time passing.
  * @return
  *  0 on success;
@@ -710,6 +723,12 @@ int raft_recv_entry(raft_server_t* me,
                     msg_entry_t* ety,
                     msg_entry_response_t *r);
 
+/** @return
+ *  nonzero if server is leader and has leases from majority of voting nodes;
+ *  0 if server is not leader or lacks leases from majority of voting nodes;
+*/
+int raft_has_majority_leases(raft_server_t* me_);
+
 /** Set this server's node ID.
  * This should be called right after raft_new/raft_clear. */
 void raft_set_nodeid(raft_server_t* me, raft_node_id_t id);
@@ -771,6 +790,9 @@ int raft_get_timeout_elapsed(raft_server_t* me);
 int raft_get_request_timeout(raft_server_t* me);
 
 /**
+ * @return lease maintenance grace in milliseconds */
+int raft_get_lease_maintenance_grace(raft_server_t* me);
+/**
  * @return index of last applied entry */
 raft_index_t raft_get_last_applied_idx(raft_server_t* me);
 
@@ -785,6 +807,10 @@ raft_index_t raft_node_get_match_idx(raft_node_t* me);
 /**
  * @return this node's user data */
 void* raft_node_get_udata(raft_node_t* me);
+
+/**
+ * @return this node's lease expiration time */
+raft_time_t raft_node_get_lease(raft_node_t* me_);
 
 /**
  * Set this node's user data */

--- a/include/raft.h
+++ b/include/raft.h
@@ -615,6 +615,11 @@ void raft_set_request_timeout(raft_server_t* me, int msec);
  * @param[in] msec Lease mainenace grace in milliseconds */
 void raft_set_lease_maintenance_grace(raft_server_t* me, int msec);
 
+/** Set "first start" flag.
+ * This indicates that me represents the first start of the (persistent)
+ * server. */
+void raft_set_first_start(raft_server_t* me);
+
 /** Process events that are dependent on time passing.
  * @return
  *  0 on success;

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -47,6 +47,9 @@ typedef struct {
     /* true if this server is in the candidate prevote state (§4.2.3, §9.6) */
     int prevote;
 
+    /* start time of this server */
+    raft_time_t start_time;
+
     /* start time of election timer */
     raft_time_t election_timer;
  
@@ -80,9 +83,6 @@ typedef struct {
     /* Last compacted snapshot */
     raft_index_t snapshot_last_idx;
     raft_term_t snapshot_last_term;
-
-    /* time when we become leader*/
-    raft_time_t inauguration;
 
     /* grace period after each lease expiration time honored when we determine
      * if a leader is maintaining leases from a majority (see raft_periodic) */
@@ -141,6 +141,10 @@ int raft_node_has_vote_for_me(raft_node_t* me_);
 void raft_node_set_has_sufficient_logs(raft_node_t* me_);
 
 void raft_node_set_lease(raft_node_t* me_, raft_time_t lease);
+
+void raft_node_set_effective_time(raft_node_t* me_, raft_time_t effective_time);
+
+raft_time_t raft_node_get_effective_time(raft_node_t* me_);
 
 int raft_votes_is_majority(const int nnodes, const int nvotes);
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -80,6 +80,13 @@ typedef struct {
     /* Last compacted snapshot */
     raft_index_t snapshot_last_idx;
     raft_term_t snapshot_last_term;
+
+    /* time when we become leader*/
+    raft_time_t inauguration;
+
+    /* grace period after each lease expiration time honored when we determine
+     * if a leader is maintaining leases from a majority (see raft_periodic) */
+    int lease_maintenance_grace;
 } raft_server_private_t;
 
 int raft_become_candidate(raft_server_t* me);
@@ -132,6 +139,8 @@ void raft_node_vote_for_me(raft_node_t* me_, const int vote);
 int raft_node_has_vote_for_me(raft_node_t* me_);
 
 void raft_node_set_has_sufficient_logs(raft_node_t* me_);
+
+void raft_node_set_lease(raft_node_t* me_, raft_time_t lease);
 
 int raft_votes_is_majority(const int nnodes, const int nvotes);
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -87,6 +87,9 @@ typedef struct {
     /* grace period after each lease expiration time honored when we determine
      * if a leader is maintaining leases from a majority (see raft_periodic) */
     int lease_maintenance_grace;
+
+    /* represents the first start of this (persistent) server; not a restart */
+    int first_start;
 } raft_server_private_t;
 
 int raft_become_candidate(raft_server_t* me);

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -30,6 +30,9 @@ typedef struct
     int flags;
 
     raft_node_id_t id;
+
+    /* lease expiration time */
+    raft_time_t lease;
 } raft_node_private_t;
 
 raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
@@ -43,6 +46,7 @@ raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
     me->match_idx = 0;
     me->id = id;
     me->flags = RAFT_NODE_VOTING;
+    me->lease = 0;
     return (raft_node_t*)me;
 }
 
@@ -140,4 +144,17 @@ raft_node_id_t raft_node_get_id(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return (NULL == me) ? -1 : me->id;
+}
+
+void raft_node_set_lease(raft_node_t* me_, raft_time_t lease)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    if (me->lease < lease)
+        me->lease = lease;
+}
+
+raft_time_t raft_node_get_lease(raft_node_t* me_)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    return me->lease;
 }

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -33,6 +33,8 @@ typedef struct
 
     /* lease expiration time */
     raft_time_t lease;
+    /* time when this node becomes part of leader's configuration */
+    raft_time_t effective_time;
 } raft_node_private_t;
 
 raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
@@ -47,6 +49,7 @@ raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
     me->id = id;
     me->flags = RAFT_NODE_VOTING;
     me->lease = 0;
+    me->effective_time = 0;
     return (raft_node_t*)me;
 }
 
@@ -157,4 +160,16 @@ raft_time_t raft_node_get_lease(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->lease;
+}
+
+void raft_node_set_effective_time(raft_node_t* me_, raft_time_t effective_time)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    me->effective_time = effective_time;
+}
+
+raft_time_t raft_node_get_effective_time(raft_node_t* me_)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    return me->effective_time;
 }

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -77,7 +77,7 @@ raft_server_t* raft_new()
     me->snapshot_in_progress = 0;
     raft_set_snapshot_metadata((raft_server_t*)me, 0, 0);
 
-    me->inauguration = 0;
+    me->start_time = 0;
     me->lease_maintenance_grace = 0;
 
     return (raft_server_t*)me;
@@ -91,8 +91,10 @@ void raft_set_callbacks(raft_server_t* me_, raft_cbs_t* funcs, void* udata)
     me->udata = udata;
     log_set_callbacks(me->log, &me->cb, me_);
 
-    /* We couldn't initialize the timer without the callback. */
-    me->election_timer = me->cb.get_time(me_, me->udata);
+    /* We couldn't initialize the time fields without the callback. */
+    raft_time_t now = me->cb.get_time(me_, me->udata);
+    me->election_timer = now;
+    me->start_time = now;
 }
 
 void raft_free(raft_server_t* me_)
@@ -121,7 +123,7 @@ void raft_clear(raft_server_t* me_)
     me->num_nodes = 0;
     me->node_id = -1;
     log_clear(me->log);
-    me->inauguration = 0;
+    me->start_time = 0;
     me->lease_maintenance_grace = 0;
 }
 
@@ -156,8 +158,8 @@ void raft_become_leader(raft_server_t* me_)
     __log(me_, NULL, "becoming leader term:%ld", raft_get_current_term(me_));
 
     raft_set_state(me_, RAFT_STATE_LEADER);
-    me->election_timer = me->cb.get_time(me_, me->udata);
-    me->inauguration = me->election_timer;
+    raft_time_t now = me->cb.get_time(me_, me->udata);
+    me->election_timer = now;
     for (i = 0; i < me->num_nodes; i++)
     {
         raft_node_t* node = me->nodes[i];
@@ -167,6 +169,7 @@ void raft_become_leader(raft_server_t* me_)
 
         raft_node_set_next_idx(node, raft_get_current_idx(me_) + 1);
         raft_node_set_match_idx(node, 0);
+        raft_node_set_effective_time(node, now);
         raft_send_appendentries(me_, node);
     }
 }
@@ -268,7 +271,33 @@ void raft_become_follower(raft_server_t* me_)
     me->election_timer = me->cb.get_time(me_, me->udata);
 }
 
-static int has_majority_leases(raft_server_t* me_, raft_time_t now, int grace)
+static int has_lease(raft_server_t* me_, raft_node_t* node, raft_time_t now, int with_grace)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+
+    if (raft_is_self(me_, node))
+        return 1;
+
+    if (with_grace)
+    {
+        if (now < raft_node_get_lease(node) + me->lease_maintenance_grace)
+            return 1;
+        /* Since a leader has no lease from any other node at the beginning of
+         * its term, or from any new node the leader adds thereafter, we give
+         * it some time to acquire the initial lease. */
+        if (now - raft_node_get_effective_time(node) < me->election_timeout + me->lease_maintenance_grace)
+            return 1;
+    }
+    else
+    {
+        if (now < raft_node_get_lease(node))
+            return 1;
+    }
+
+    return 0;
+}
+
+static int has_majority_leases(raft_server_t* me_, raft_time_t now, int with_grace)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     assert(me->state == RAFT_STATE_LEADER);
@@ -282,8 +311,7 @@ static int has_majority_leases(raft_server_t* me_, raft_time_t now, int grace)
         if (raft_node_is_voting(me->nodes[i]))
         {
             n_voting++;
-            if (raft_is_self(me_, me->nodes[i]) ||
-                now < raft_node_get_lease(me->nodes[i]) + grace)
+            if (has_lease(me_, me->nodes[i], now, with_grace))
                 n++;
         }
     }
@@ -298,7 +326,9 @@ int raft_has_majority_leases(raft_server_t* me_)
     if (me->state != RAFT_STATE_LEADER)
         return 0;
 
-    return has_majority_leases(me_, me->cb.get_time(me_, me->udata), 0 /* grace */);
+    /* Check without grace, because the caller may be checking leadership for
+     * linearizability (§6.4). */
+    return has_majority_leases(me_, me->cb.get_time(me_, me->udata), 0 /* with_grace */);
 }
 
 int raft_periodic(raft_server_t* me_)
@@ -309,12 +339,9 @@ int raft_periodic(raft_server_t* me_)
 
     if (me->state == RAFT_STATE_LEADER)
     {
-        if (me->election_timeout + me->lease_maintenance_grace < now - me->inauguration &&
-            !has_majority_leases(me_, now, me->lease_maintenance_grace))
+        if (!has_majority_leases(me_, now, 1 /* with_grace */))
         {
-            /* A leader who can't maintain leases from a majority shall step
-             * down. Since a leader doesn't have any leases at the beginning of
-             * its term, we give it some time to acquire the initial leases. */
+            /* A leader who can't maintain majority leases shall step down. */
             __log(me_, NULL, "unable to maintain majority leases");
             raft_become_follower(me_);
             me->leader_id = -1;
@@ -664,9 +691,11 @@ int raft_recv_requestvote(raft_server_t* me_,
     if (!node)
         node = raft_get_node(me_, vr->candidate_id);
 
-    /* Reject request if we have a leader */
-    if (me->leader_id != -1 && me->leader_id != vr->candidate_id &&
-        now - me->election_timer < me->election_timeout)
+    /* Reject request if we have a leader or if we have just started (for we might
+     * have granted a lease before a restart) */
+    if ((me->leader_id != -1 && me->leader_id != vr->candidate_id &&
+         now - me->election_timer < me->election_timeout) ||
+        now - me->start_time < me->election_timeout)
     {
         r->vote_granted = 0;
         goto done;
@@ -1158,6 +1187,8 @@ raft_node_t* raft_add_node_internal(raft_server_t* me_, raft_entry_t *ety, void*
     node = raft_node_new(udata, id);
     if (!node)
         return NULL;
+    if (raft_is_leader(me_))
+        raft_node_set_effective_time(node, me->cb.get_time(me_, me->udata));
     void* p = realloc(me->nodes, sizeof(void*) * (me->num_nodes + 1));
     if (!p) {
         raft_node_free(node);

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -79,6 +79,7 @@ raft_server_t* raft_new()
 
     me->start_time = 0;
     me->lease_maintenance_grace = 0;
+    me->first_start = 0;
 
     return (raft_server_t*)me;
 }
@@ -125,6 +126,7 @@ void raft_clear(raft_server_t* me_)
     log_clear(me->log);
     me->start_time = 0;
     me->lease_maintenance_grace = 0;
+    me->first_start = 0;
 }
 
 int raft_delete_entry_from_idx(raft_server_t* me_, raft_index_t idx)
@@ -695,7 +697,7 @@ int raft_recv_requestvote(raft_server_t* me_,
      * have granted a lease before a restart) */
     if ((me->leader_id != -1 && me->leader_id != vr->candidate_id &&
          now - me->election_timer < me->election_timeout) ||
-        now - me->start_time < me->election_timeout)
+        (!me->first_start && now - me->start_time < me->election_timeout))
     {
         r->vote_granted = 0;
         goto done;

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -38,6 +38,12 @@ void raft_set_lease_maintenance_grace(raft_server_t* me_, int millisec)
     me->lease_maintenance_grace = millisec;
 }
 
+void raft_set_first_start(raft_server_t* me_)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    me->first_start = 1;
+}
+
 void raft_set_nodeid(raft_server_t* me_, raft_node_id_t id)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -32,6 +32,12 @@ void raft_set_request_timeout(raft_server_t* me_, int millisec)
     me->request_timeout = millisec;
 }
 
+void raft_set_lease_maintenance_grace(raft_server_t* me_, int millisec)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    me->lease_maintenance_grace = millisec;
+}
+
 void raft_set_nodeid(raft_server_t* me_, raft_node_id_t id)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
@@ -53,6 +59,11 @@ int raft_get_election_timeout(raft_server_t* me_)
 int raft_get_request_timeout(raft_server_t* me_)
 {
     return ((raft_server_private_t*)me_)->request_timeout;
+}
+
+int raft_get_lease_maintenance_grace(raft_server_t* me_)
+{
+    return ((raft_server_private_t*)me_)->lease_maintenance_grace;
 }
 
 int raft_get_num_nodes(raft_server_t* me_)

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -1104,7 +1104,7 @@ void TestRaft_server_recv_requestvote_reply_true_if_term_greater_than_or_equal_t
     raft_set_current_term(r, 1);
     wait_for_startup_lease(r);
 
-    /* term is less than current term */
+    /* term is greater than current term */
     memset(&rv, 0, sizeof(msg_requestvote_t));
     rv.term = 2;
     rv.last_log_idx = 1;


### PR DESCRIPTION
This patch implements two features:

  - Leadership leases (aka leases) for leaders to reduce RPCs sent just to verify leaderships. A leadership lease is a promise by a follower that it will not grant any new vote until a certain time, referred to as the lease expiration time. If a leader has valid leases, that is, leases that have not expired, from a majority of the voting nodes, then it may assume that no other leader could have committed any new entries behind its back.

  - Voluntarily stepping down for leaders who are unable to maintain leases from a majority of the voting nodes. Clients who already know about this leader will then start a new leader search, rather than stick with this leader who is unable to commit any entries.

The library API sees the following changes:

  - New lease field in AE and IS responses. These represent lease expiration times, which the user may adjust to accommodate clock offsets among nodes.

  - New function raft_has_majority_leases. This function enables the user to verify leadership before reads in an efficient manner.

  - New functions raft_{set,get}_lease_maintenance_grace. This new tunable allows the user to grant a leader more time to re-establish expired leases to avoid stepping down. For instance, the user may set a grace to offset any clock offset adjustment to lease expiration times, or to be more conservative for voluntarily stepping down.