### PR TITLE
DAOS-12944 tests: Fix some semantic conflicts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+raft (0.10.1-1) unstable; urgency=medium
+
+  [ Li Wei ]
+  * Fix conflicts in a unit test
+
+ -- Li Wei <wei.g.li@intel.com>  Wed, 07 Jun 2023 15:41:00 +0900
+
 raft (0.10.0-1) unstable; urgency=medium
 
   [ Li Wei ]

--- a/raft.spec
+++ b/raft.spec
@@ -9,7 +9,7 @@
 %global debug_package %{nil}
 
 Name:		raft
-Version:	0.10.0
+Version:	0.10.1
 Release:	1%{?relval}%{?dist}
 
 Summary:	C implementation of the Raft Consensus protocol, BSD licensed
@@ -62,6 +62,9 @@ cp -a include/* %{buildroot}/%{_includedir}
 
 
 %changelog
+* Wed Jun 07 2023 Li Wei <wei.g.li@intel.com> -0.10.1-1
+- Fix conflicts in a unit test
+
 * Mon Jun 05 2023 Li Wei <wei.g.li@intel.com> -0.10.0-1
 - Add leadership lease
 - Let leaders step down voluntarily when they can't maintain leases from majority


### PR DESCRIPTION
It turns out that #71 has some semantic conflicts with the unit test added by #70:

  - #71 removes a raft_period parameter.
  - #71 requires an implementation of the get_time callback.
  - #71 asks leaders to step down if they cannot maintain majority leases.

Because I forgot to verify the unit tests after resolving the textual conflict, the unit test added by #70 does not compile. This patch fixes the problems.