### PR TITLE
DAOS-13965 include: Add logging levels

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+raft (0.11.0-1) unstable; urgency=medium
+
+  [ Li Wei ]
+  * Add raft_cbs_t.get_rand
+  * Introduce logging levels
+
+ -- Li Wei <wei.g.li@intel.com>  Wed, 14 Feb 2024 15:43:00 +0900
+
 raft (0.10.1-1) unstable; urgency=medium
 
   [ Li Wei ]

--- a/include/raft.h
+++ b/include/raft.h
@@ -26,6 +26,12 @@ typedef enum {
 } raft_error_e;
 
 typedef enum {
+    RAFT_LOG_ERROR,
+    RAFT_LOG_INFO,
+    RAFT_LOG_DEBUG,
+} raft_loglevel_e;
+
+typedef enum {
     RAFT_MEMBERSHIP_ADD,
     RAFT_MEMBERSHIP_REMOVE,
 } raft_membership_e;
@@ -353,6 +359,7 @@ typedef int (
  * @param[in] raft The Raft server making this callback
  * @param[in] node The node that is the subject of this log. Could be NULL.
  * @param[in] user_data User data that is passed from Raft server
+ * @param[in] level The log level
  * @param[in] buf The buffer that was logged */
 typedef void (
 *func_log_f
@@ -360,6 +367,7 @@ typedef void (
     raft_server_t* raft,
     raft_node_t* node,
     void *user_data,
+    raft_loglevel_e level,
     const char *buf
     );
 #endif
@@ -560,6 +568,11 @@ typedef struct
      * - a (IP,Port) tuple */
     void* udata_address;
 } raft_node_configuration_t;
+
+/** Set the global logging level.
+ * Only those messages at levels less than or equal to this level will be
+ * logged. Default to RAFT_LOG_INFO. */
+void raft_set_log_level(raft_loglevel_e level);
 
 /** Initialise a new Raft server.
  *

--- a/packaging/ccache-stats.patch
+++ b/packaging/ccache-stats.patch
@@ -1,0 +1,66 @@
+From e87d916d7f49ea4949973adf0f09e9e5bf891e03 Mon Sep 17 00:00:00 2001
+From: "Brian J. Murrell" <brian@interlinx.bc.ca>
+Date: Tue, 30 Jan 2024 11:03:12 -0500
+Subject: [PATCH 1/2] Show ccache stats at the end of the build
+
+Zero the ccache stats at the beginning of the build and then display the
+ccache stats at the end of the build to see how effective ccache was.
+
+Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>
+---
+ mock/py/mockbuild/plugins/ccache.py | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/mock/py/mockbuild/plugins/ccache.py b/mock/py/mockbuild/plugins/ccache.py
+index 2666ad9fc..1080ffe68 100644
+--- a/mock/py/mockbuild/plugins/ccache.py
++++ b/mock/py/mockbuild/plugins/ccache.py
+@@ -35,6 +35,7 @@ def __init__(self, plugins, conf, buildroot):
+         buildroot.preexisting_deps.append("ccache")
+         plugins.add_hook("prebuild", self._ccacheBuildHook)
+         plugins.add_hook("preinit", self._ccachePreInitHook)
++        plugins.add_hook("postbuild", self._ccachePostBuildHook)
+         buildroot.mounts.add(
+             BindMountPoint(srcpath=self.ccachePath, bindpath=buildroot.make_chroot_path("/var/tmp/ccache")))
+
+@@ -47,6 +48,9 @@ def __init__(self, plugins, conf, buildroot):
+     @traceLog()
+     def _ccacheBuildHook(self):
+         self.buildroot.doChroot(["ccache", "-M", str(self.ccache_opts['max_cache_size'])], shell=False)
++        # zero ccache stats
++        getLog().info("Zero ccache stats:")
++        self.buildroot.doChroot(["ccache", "--zero-stats"], printOutput=True, shell=False)
+
+     # set up the ccache dir.
+     # we also set a few variables used by ccache to find the shared cache.
+@@ -61,3 +65,10 @@ def _ccachePreInitHook(self):
+         file_util.mkdirIfAbsent(self.buildroot.make_chroot_path('/var/tmp/ccache'))
+         file_util.mkdirIfAbsent(self.ccachePath)
+         self.buildroot.uid_manager.changeOwner(self.ccachePath, recursive=True)
++
++    # get some cache stats
++    def _ccachePostBuildHook(self):
++        # show the cache hit stats
++        getLog().info("ccache stats:")
++        self.buildroot.doChroot(["ccache", "--show-stats"], printOutput=True, shell=False)
+++
+
+From bfd3a7e1bb47d28ee60a94cb5985c1f66476475f Mon Sep 17 00:00:00 2001
+From: "Brian J. Murrell" <brian@interlinx.bc.ca>
+Date: Tue, 30 Jan 2024 11:17:48 -0500
+Subject: [PATCH 2/2] Remove extraneous line
+
+Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>
+---
+ mock/py/mockbuild/plugins/ccache.py | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/mock/py/mockbuild/plugins/ccache.py b/mock/py/mockbuild/plugins/ccache.py
+index 1080ffe68..1a20846d3 100644
+--- a/mock/py/mockbuild/plugins/ccache.py
++++ b/mock/py/mockbuild/plugins/ccache.py
+@@ -71,4 +71,3 @@ def _ccachePostBuildHook(self):
+         # show the cache hit stats
+         getLog().info("ccache stats:")
+         self.buildroot.doChroot(["ccache", "--show-stats"], printOutput=True, shell=False)
+-+

--- a/packaging/get_base_branch
+++ b/packaging/get_base_branch
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# find the base branch of the current branch
+
+set -eux -o pipefail
+IFS=' ' read -r -a add_bases <<< "${1:-}"
+origin=origin
+mapfile -t all_bases < <(echo "master"
+                         git branch -r | sed -ne "/^  $origin\\/release\\/[0-9]/s/^  $origin\\///p")
+all_bases+=("${add_bases[@]}")
+TARGET="master"
+min_diff=-1
+for base in "${all_bases[@]}"; do
+    git rev-parse --verify "$origin/$base" &> /dev/null || continue
+    commits_ahead=$(git log --oneline "$origin/$base..HEAD" | wc -l)
+    if [ "$min_diff" -eq -1 ] || [ "$min_diff" -gt "$commits_ahead" ]; then
+        TARGET="$base"
+        min_diff=$commits_ahead
+    fi
+done
+echo "$TARGET"
+exit 0

--- a/raft.spec
+++ b/raft.spec
@@ -9,8 +9,8 @@
 %global debug_package %{nil}
 
 Name:		raft
-Version:	0.10.1
-Release:	2%{?relval}%{?dist}
+Version:	0.11.0
+Release:	1%{?relval}%{?dist}
 
 Summary:	C implementation of the Raft Consensus protocol, BSD licensed
 Provides:	daos-raft = %version-%release%{?dist}
@@ -64,6 +64,10 @@ cp -a include/* %{buildroot}/%{_includedir}
 
 
 %changelog
+* Wed Feb 14 2024 Li Wei <wei.g.li@intel.com> -0.11.0-1
+- Add raft_cbs_t.get_rand
+- Introduce logging levels
+
 * Thu Jun 22 2023 Brian J. Murrell <brian.murrell@intel> -0.10.1-2
 - Add BR: make, gcc
 


### PR DESCRIPTION
Add a new level parameter to raft_cbs_t.log, so that we will be able to
enable the logging of errors and certain low-frequency messages without
being flooded by high-frequency messages from AEs.