### PR TITLE
DAOS-15120 include: Add get_rand to raft_cbs_t

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -469,6 +469,17 @@ typedef raft_time_t (
     void *user_data
     );
 
+/** Callback for getting a pseudo-random double in [0, 1).
+ * @param[in] raft The Raft server making this callback
+ * @param[in] user_data User data that is passed from Raft server
+ * @return The pseudo-random number */
+typedef double (
+*func_get_rand_f
+)   (
+    raft_server_t* raft,
+    void *user_data
+    );
+
 typedef struct
 {
     /** Callback for sending request vote messages */
@@ -536,6 +547,9 @@ typedef struct
 
     /** Callback for getting the current time */
     func_get_time_f get_time;
+
+    /** Callback for getting a pseudo-random number */
+    func_get_rand_f get_rand;
 } raft_cbs_t;
 
 typedef struct

--- a/packaging/Dockerfile.mockbuild
+++ b/packaging/Dockerfile.mockbuild
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2023 Intel Corporation
+# Copyright 2018-2024 Intel Corporation
 #
 # 'recipe' for Docker to build an RPM
 #
@@ -48,16 +48,24 @@ RUN dnf -y upgrade && \
 # https://github.com/rpm-software-management/rpmlint/pull/795 in it
 # But make sure to patch after dnf upgrade so that an upgraded rpmlint
 # RPM doesn't wipe out our patch
+# Ditto for the patch to zero and display ccache stats
+# https://github.com/rpm-software-management/mock/pull/1299
 ARG PACKAGINGDIR=packaging
-COPY ${PACKAGINGDIR}/rpmlint--ignore-unused-rpmlintrc.patch .
+COPY ${PACKAGINGDIR}/*.patch ./
 RUN (cd $(python3 -c 'import site; print(site.getsitepackages()[-1])') &&                      \
      if ! grep -e --ignore-unused-rpmlintrc rpmlint/cli.py; then                               \
-         if ! patch -p1; then                                                                  \
+         if ! patch -p1 < $OLDPWD/rpmlint--ignore-unused-rpmlintrc.patch; then                 \
              exit 1;                                                                           \
          fi;                                                                                   \
          rm -f rpmlint/__pycache__/{cli,lint}.*.pyc;                                           \
-     fi) < rpmlint--ignore-unused-rpmlintrc.patch;                                             \
-    rm -f  rpmlint--ignore-unused-rpmlintrc.patch
+     fi;                                                                                       \
+     if ! grep _ccachePostBuildHook mockbuild/plugins/ccache.py; then                          \
+         if ! patch -p3 < $OLDPWD/ccache-stats.patch; then                                     \
+             exit 1;                                                                           \
+         fi;                                                                                   \
+         rm -f mockbuild/plugins/__pycache__/ccache.*.pyc;                                     \
+     fi);                                                                                      \
+     rm -f rpmlint--ignore-unused-rpmlintrc.patch ccache-stats.patch
 
 # show the release that was built
 ARG CACHEBUST

--- a/packaging/Makefile_packaging.mk
+++ b/packaging/Makefile_packaging.mk
@@ -364,6 +364,7 @@ chrootbuild: $(SRPM) $(CALLING_MAKEFILE)
 	LOCAL_REPOS='$(LOCAL_REPOS)'                            \
 	ARTIFACTORY_URL="$(ARTIFACTORY_URL)"                    \
 	DISTRO_VERSION="$(DISTRO_VERSION)"                      \
+	PACKAGE="$(NAME)"                                       \
 	TARGET="$<"                                             \
 	packaging/rpm_chrootbuild
 endif

--- a/packaging/rpm_chrootbuild
+++ b/packaging/rpm_chrootbuild
@@ -4,6 +4,13 @@ set -uex
 
 cp /etc/mock/"$CHROOT_NAME".cfg mock.cfg
 
+# Enable mock ccache plugin
+cat <<EOF >> mock.cfg
+config_opts['plugin_conf']['ccache_enable'] = True
+config_opts['plugin_conf']['ccache_opts']['dir'] = "%(cache_topdir)s/%(root)s/ccache/"
+EOF
+
+
 if [[ $CHROOT_NAME == *epel-8-x86_64 ]]; then
     cat <<EOF >> mock.cfg
 config_opts['module_setup_commands'] = [
@@ -103,24 +110,30 @@ if [ -n "$DISTRO_VERSION" ]; then
 fi
 
 bs_dir=/scratch/mock/cache/"${CHROOT_NAME}"-bootstrap
-if ls -l /scratch/mock/cache/"${CHROOT_NAME}"-bootstrap/root_cache/cache.tar.gz; then
-    mkdir -p "/var/cache/mock/${CHROOT_NAME}-bootstrap"
+if ls -l "$bs_dir"/root_cache/cache.tar.gz; then
+    mkdir -p "/var/cache/mock/${CHROOT_NAME}-bootstrap/"
     flock "$bs_dir" -c "cp -a $bs_dir/root_cache /var/cache/mock/${CHROOT_NAME}-bootstrap"
+fi
+if ls -l "$bs_dir/ccache-$CHROOT_NAME-$PACKAGE".tar.gz; then
+    flock "$bs_dir" -c "tar -C / -xzf $bs_dir/ccache-$CHROOT_NAME-$PACKAGE.tar.gz"
 fi
 
 rc=0
 # shellcheck disable=SC2086,SC2048
-if ! eval mock -r mock.cfg ${repo_dels[*]} ${repo_adds[*]} --no-clean \
-          --disablerepo=\*-debug* ${releasever_opt[*]} $MOCK_OPTIONS  \
-          $RPM_BUILD_OPTIONS "$TARGET"; then
+if ! eval time mock -r mock.cfg ${repo_dels[*]} ${repo_adds[*]} --no-clean \
+                    --disablerepo=\*-debug* ${releasever_opt[*]} $MOCK_OPTIONS  \
+                    $RPM_BUILD_OPTIONS "$TARGET"; then
     rc=${PIPESTATUS[0]}
 fi
 
-if ls -l /var/cache/mock/"${CHROOT_NAME}"-bootstrap/root_cache/cache.tar.gz &&
-   [ -d /scratch/ ]; then
-    mkdir -p /scratch/mock/cache/"${CHROOT_NAME}"-bootstrap/
-    if ! cmp /var/cache/mock/"${CHROOT_NAME}"-bootstrap/root_cache/cache.tar.gz "$bs_dir"/root_cache/cache.tar.gz; then
-        flock "$bs_dir" -c "cp -a /var/cache/mock/${CHROOT_NAME}-bootstrap/root_cache $bs_dir/"
+# Save the ccache
+if [ -d /scratch/ ]; then
+    mkdir -p "$bs_dir"/
+    flock "$bs_dir" -c "tar -czf $bs_dir/ccache-$CHROOT_NAME-$PACKAGE.tar.gz /var/cache/mock/${CHROOT_NAME}/ccache"
+    if ls -l /var/cache/mock/"${CHROOT_NAME}"-bootstrap/root_cache/cache.tar.gz; then
+        if ! cmp /var/cache/mock/"${CHROOT_NAME}"-bootstrap/root_cache/cache.tar.gz "$bs_dir"/root_cache/cache.tar.gz; then
+            flock "$bs_dir" -c "cp -a /var/cache/mock/${CHROOT_NAME}-bootstrap/root_cache $bs_dir/"
+        fi
     fi
 fi
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -43,12 +43,24 @@ static void __log(raft_server_t *me_, raft_node_t* node, const char *fmt, ...)
     va_end(args);
 }
 
+static double get_rand(raft_server_t* me_)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    if (me->cb.get_rand == NULL) {
+        int r = rand();
+        if (r == RAND_MAX)
+            r = 0;
+        return (double)r / RAND_MAX;
+    }
+    return me->cb.get_rand(me_, me->udata);
+}
+
 void raft_randomize_election_timeout(raft_server_t* me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
 
     /* [election_timeout, 2 * election_timeout) */
-    me->election_timeout_rand = me->election_timeout + rand() % me->election_timeout;
+    me->election_timeout_rand = me->election_timeout * (1 + get_rand(me_));
     __log(me_, NULL, "randomize election timeout to %d", me->election_timeout_rand);
 }
 


### PR DESCRIPTION
Add a new callback, get_rand, to raft_cbs_t, so that a user can choose his preferred pseudo-random number generator (PRNG). For instance, one can maintain his own PRNG instance in user_data (or elsewhere), to avoid consuming numbers from the default, global PRNG instance (e.g., the instance behind rand(3), which a library shall not seed).