### PR TITLE
DAOS-10139 include: Allow 64-bit node IDs

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -445,6 +445,16 @@ typedef int (
     raft_index_t entry_idx
     );
 
+/** Callback for getting the node ID from a cfg log entry. */
+typedef raft_node_id_t (
+*func_get_node_id_f
+)   (
+    raft_server_t* raft,
+    void *user_data,
+    raft_entry_t *entry,
+    raft_index_t entry_idx
+    );
+
 /** Callback for being notified of membership changes.
  *
  * Implementing this callback is optional.
@@ -542,7 +552,7 @@ typedef struct
      * affects. This call only applies to configuration change log entries.
      * @note entry_idx may be 0, indicating that the index is unknown.
      * @return the node ID of the node */
-    func_logentry_event_f log_get_node_id;
+    func_get_node_id_f log_get_node_id;
 
     /** Callback for detecting when a non-voting node has sufficient logs. */
     func_node_has_sufficient_logs_f node_has_sufficient_logs;

--- a/include/raft_types.h
+++ b/include/raft_types.h
@@ -25,7 +25,7 @@ typedef long int raft_index_t;
 /**
  * Unique node identifier.
  */
-typedef int raft_node_id_t;
+typedef long int raft_node_id_t;
 
 /**
  * Timestamp in milliseconds.

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -69,7 +69,7 @@ static int __raft_send_appendentries(raft_server_t* raft,
     return 0;
 }
 
-static int __raft_log_get_node_id(raft_server_t* raft,
+static raft_node_id_t __raft_log_get_node_id(raft_server_t* raft,
         void *udata,
         raft_entry_t *entry,
         raft_index_t entry_idx)


### PR DESCRIPTION
Change raft_node_id_t from int to long so that it'll be easier for users to generate unique node IDs. (Using conditional compilation turns out to be tricky, because users' build system must define consistent macro values throughout. I believe that we must introduce a configuration phase for this library to support that well.)